### PR TITLE
fix: 2026-06-04 audit — framework isolation, perf, UX, a11y + cleanups

### DIFF
--- a/apps/web/src/components/asset-render/AssetRender.tsx
+++ b/apps/web/src/components/asset-render/AssetRender.tsx
@@ -1,0 +1,53 @@
+/**
+ * `<AssetRender>` — modality-aware router for `AssetGenerateView` payloads
+ * arriving over the `asset.generated` SSE channel (P0-b, SPEC §5.7).
+ *
+ * Routing table:
+ *   `image` → AssetImage
+ *   `audio` → AssetAudio
+ *   *anything else (`tile` / `avatar` / `dialogue-asset` / `video` / future
+ *    modalities)* → AssetGenericLink
+ *
+ * The framework intentionally does not enumerate every modality here —
+ * SPEC §5.7 keeps the modality string open so plugin authors can ship new
+ * shapes without a framework PR. P0 ships sensible defaults for the two
+ * modalities the kernel currently emits and a generic-link fallback for
+ * everything else.
+ *
+ * Lives in its own module (not the `index.tsx` barrel) so `AssetTurnSidebar`
+ * can import it without forming a barrel import cycle.
+ *
+ * Data flow:
+ *   kernel.commitProposal(asset.generate)
+ *     → emit('asset.generated', { asset: AssetGenerateView })
+ *     → web SSE handler
+ *     → session-store reducer state.assetsByTurn
+ *     → <AssetTurnSidebar turnId={...}>
+ *     → <AssetRender view={...}>
+ *     → <AssetImage|AssetAudio|AssetGenericLink>
+ */
+
+import type { ReactElement } from "react";
+import type { AssetGenerateView } from "@covel/shared";
+import { AssetImage } from "./AssetImage.js";
+import { AssetAudio } from "./AssetAudio.js";
+import { AssetGenericLink } from "./AssetGenericLink.js";
+
+export interface AssetRenderProps {
+  readonly view: AssetGenerateView;
+  readonly sessionId: string;
+}
+
+export function AssetRender({
+  view,
+  sessionId,
+}: AssetRenderProps): ReactElement {
+  switch (view.modality) {
+    case "image":
+      return <AssetImage view={view} sessionId={sessionId} />;
+    case "audio":
+      return <AssetAudio view={view} sessionId={sessionId} />;
+    default:
+      return <AssetGenericLink view={view} sessionId={sessionId} />;
+  }
+}

--- a/apps/web/src/components/asset-render/AssetTurnSidebar.tsx
+++ b/apps/web/src/components/asset-render/AssetTurnSidebar.tsx
@@ -19,7 +19,7 @@
 
 import type { ReactElement } from "react";
 import { useSession } from "@/stores/session-store.js";
-import { AssetRender } from "./index.js";
+import { AssetRender } from "./AssetRender.js";
 
 export interface AssetTurnSidebarProps {
   readonly turnId: string;

--- a/apps/web/src/components/asset-render/index.tsx
+++ b/apps/web/src/components/asset-render/index.tsx
@@ -1,54 +1,10 @@
 /**
- * `<AssetRender>` — modality-aware router for `AssetGenerateView` payloads
- * arriving over the `asset.generated` SSE channel (P0-b, SPEC §5.7).
- *
- * Routing table:
- *   `image` → AssetImage
- *   `audio` → AssetAudio
- *   *anything else (`tile` / `avatar` / `dialogue-asset` / `video` / future
- *    modalities)* → AssetGenericLink
- *
- * The framework intentionally does not enumerate every modality here —
- * SPEC §5.7 keeps the modality string open so plugin authors can ship new
- * shapes without a framework PR. P0 ships sensible defaults for the two
- * modalities the kernel currently emits and a generic-link fallback for
- * everything else.
- *
- * Data flow:
- *   kernel.commitProposal(asset.generate)
- *     → emit('asset.generated', { asset: AssetGenerateView })
- *     → web SSE handler
- *     → session-store reducer state.assetsByTurn
- *     → <AssetTurnSidebar turnId={...}>
- *     → <AssetRender view={...}>
- *     → <AssetImage|AssetAudio|AssetGenericLink>
+ * Public barrel for the asset-render family. Pure aggregation only — the
+ * `<AssetRender>` router lives in `./AssetRender.tsx` so `AssetTurnSidebar`
+ * can depend on it without a barrel import cycle.
  */
 
-import type { ReactElement } from "react";
-import type { AssetGenerateView } from "@covel/shared";
-import { AssetImage } from "./AssetImage.js";
-import { AssetAudio } from "./AssetAudio.js";
-import { AssetGenericLink } from "./AssetGenericLink.js";
-
-export interface AssetRenderProps {
-  readonly view: AssetGenerateView;
-  readonly sessionId: string;
-}
-
-export function AssetRender({
-  view,
-  sessionId,
-}: AssetRenderProps): ReactElement {
-  switch (view.modality) {
-    case "image":
-      return <AssetImage view={view} sessionId={sessionId} />;
-    case "audio":
-      return <AssetAudio view={view} sessionId={sessionId} />;
-    default:
-      return <AssetGenericLink view={view} sessionId={sessionId} />;
-  }
-}
-
+export { AssetRender, type AssetRenderProps } from "./AssetRender.js";
 export { AssetImage } from "./AssetImage.js";
 export { AssetAudio } from "./AssetAudio.js";
 export { AssetGenericLink } from "./AssetGenericLink.js";

--- a/apps/web/src/components/session/chat-messages.tsx
+++ b/apps/web/src/components/session/chat-messages.tsx
@@ -26,7 +26,6 @@ import {
   postPluginRpcWithApproval,
 } from "./plugin-rpc-ui.js";
 import {
-  BranchReplyBlock,
   MessageBlockRenderer,
   PluginMessageBlock,
   UiRenderBlock,
@@ -420,22 +419,10 @@ export function ChatMessages({
       );
     }
 
-    if (blockType === "branch_reply" || blockType === "branch-reply") {
-      return (
-        <div key={msg.id} className="flex flex-col gap-1.5">
-          {viewMode === "detailed" && (
-            <span className="text-[10px] font-mono text-muted-foreground/70 uppercase tracking-wider">
-              branch-reply
-              {msg.runtimeId && (
-                <span className="ml-1.5 opacity-60">· {msg.runtimeId}</span>
-              )}
-            </span>
-          )}
-          <BranchReplyBlock block={block} pluginId={msg.runtimeId} />
-          <SubmittedSelectionFooter values={submittedValues} />
-        </div>
-      );
-    }
+    // NOTE: branch-reply blocks are NOT special-cased here. The branch-reply
+    // plugin renders through the standard plugin-message surface (its
+    // `ui.message` spec → `BranchReplyCandidates` catalog component), so the
+    // framework never hardcodes the plugin's block type (CLAUDE.md isolation).
 
     const assetView = isAssetGenerateView(block.data) ? block.data : null;
     if (blockType === "asset.generate" && sessionId && assetView) {

--- a/apps/web/src/components/session/chat-messages.tsx
+++ b/apps/web/src/components/session/chat-messages.tsx
@@ -431,7 +431,7 @@ export function ChatMessages({
               )}
             </span>
           )}
-          <BranchReplyBlock block={block} />
+          <BranchReplyBlock block={block} pluginId={msg.runtimeId} />
           <SubmittedSelectionFooter values={submittedValues} />
         </div>
       );

--- a/apps/web/src/components/session/chat-messages.tsx
+++ b/apps/web/src/components/session/chat-messages.tsx
@@ -578,7 +578,17 @@ export function ChatMessages({
                 );
               }
 
-              return rendered;
+              // Wrap each row in a `.chat-row` so off-screen rows skip layout
+              // and paint (content-visibility) — preserves keys, refs, state,
+              // scroll anchoring, streaming follow and jump-to-latest.
+              return rendered.map((node) => {
+                const el = node as React.ReactElement;
+                return (
+                  <div key={el.key} className="chat-row">
+                    {node}
+                  </div>
+                );
+              });
             })()}
 
             {executionError && (

--- a/apps/web/src/components/session/chat-messages/message-blocks.tsx
+++ b/apps/web/src/components/session/chat-messages/message-blocks.tsx
@@ -176,39 +176,6 @@ function normalizeNestedSpec(
   return out;
 }
 
-export function BranchReplyBlock({
-  block,
-  pluginId,
-}: {
-  block: Record<string, unknown>;
-  /** Authoring plugin id, sourced from the message — never hardcoded here. */
-  pluginId?: string;
-}) {
-  const data = (block.data ?? block) as Record<string, unknown>;
-  const resolvedPluginId =
-    pluginId ?? (typeof data.pluginId === "string" ? data.pluginId : undefined);
-  const spec = useMemo(
-    () =>
-      nestedToFlat({
-        type: "BranchReplyCandidates",
-        props: {
-          value: data,
-          // Pass the real authoring plugin id when known; the catalog renderer
-          // keeps its own last-resort default. The framework does not inject a
-          // hardcoded plugin id.
-          ...(resolvedPluginId ? { pluginId: resolvedPluginId } : {}),
-        },
-      }),
-    [data, resolvedPluginId],
-  );
-
-  return (
-    <JSONUIProvider registry={covelRegistry} initialState={{}} handlers={{}}>
-      <Renderer spec={spec} registry={covelRegistry} />
-    </JSONUIProvider>
-  );
-}
-
 // Renders any block other than plugin_message using message-to-spec +
 // json-render. Form/choice handlers bridge into onSubmitInteraction so
 // the framework submit-form RPC + echoFilledNarrative UX hint keeps

--- a/apps/web/src/components/session/chat-messages/message-blocks.tsx
+++ b/apps/web/src/components/session/chat-messages/message-blocks.tsx
@@ -178,20 +178,28 @@ function normalizeNestedSpec(
 
 export function BranchReplyBlock({
   block,
+  pluginId,
 }: {
   block: Record<string, unknown>;
+  /** Authoring plugin id, sourced from the message — never hardcoded here. */
+  pluginId?: string;
 }) {
   const data = (block.data ?? block) as Record<string, unknown>;
+  const resolvedPluginId =
+    pluginId ?? (typeof data.pluginId === "string" ? data.pluginId : undefined);
   const spec = useMemo(
     () =>
       nestedToFlat({
         type: "BranchReplyCandidates",
         props: {
           value: data,
-          pluginId: "branch-reply",
+          // Pass the real authoring plugin id when known; the catalog renderer
+          // keeps its own last-resort default. The framework does not inject a
+          // hardcoded plugin id.
+          ...(resolvedPluginId ? { pluginId: resolvedPluginId } : {}),
         },
       }),
-    [data],
+    [data, resolvedPluginId],
   );
 
   return (

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -614,6 +614,21 @@
   max-width: var(--session-column-max-width);
 }
 
+/*
+ * Chat list off-screen render-skipping (P1-E). `content-visibility: auto`
+ * skips layout + paint for rows outside the viewport without unmounting them,
+ * so refs, component state, scroll anchoring, streaming follow, and the
+ * jump-to-latest affordance all keep working. `contain-intrinsic-size: auto …`
+ * lets the browser remember each row's real measured height after first paint,
+ * keeping the scrollbar stable on scrollback. The 240px is only the first-paint
+ * estimate for never-yet-rendered off-screen rows. Degrades to a normal render
+ * in browsers without `content-visibility`.
+ */
+.chat-row {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 240px;
+}
+
 /* Meters / progress */
 .ui-meter-track {
   background: var(--color-muted);

--- a/apps/web/src/services/app-kv-store.ts
+++ b/apps/web/src/services/app-kv-store.ts
@@ -116,8 +116,8 @@ export async function removeStateSnapshot(sessionId: string): Promise<void> {
 
 export async function getStatePatches(
   sessionId: string,
-): Promise<import("./api.js").StatePatchRecord[] | null> {
-  return idbGet<import("./api.js").StatePatchRecord[]>(
+): Promise<import("./api/types.js").StatePatchRecord[] | null> {
+  return idbGet<import("./api/types.js").StatePatchRecord[]>(
     STORE_STATE_PATCHES,
     sessionId,
   );
@@ -125,7 +125,7 @@ export async function getStatePatches(
 
 export async function saveStatePatches(
   sessionId: string,
-  patches: import("./api.js").StatePatchRecord[],
+  patches: import("./api/types.js").StatePatchRecord[],
 ): Promise<void> {
   return idbPut(STORE_STATE_PATCHES, sessionId, patches);
 }

--- a/package.json
+++ b/package.json
@@ -59,12 +59,5 @@
     "tsx": "^4.21.0",
     "turbo": "^2.9.6",
     "yaml": "^2.8.3"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "electron",
-      "esbuild"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,10 @@ packages:
   - "plugins/*"
 
 minimumReleaseAge: 10080
+
+# Native packages allowed to run install build scripts. Moved here from the
+# package.json `pnpm` field, which pnpm 10 no longer reads.
+onlyBuiltDependencies:
+  - better-sqlite3
+  - electron
+  - esbuild


### PR DESCRIPTION
## Overview

Resolves the findings from the 2026-06-04 multi-dimension codebase audit
(correctness/security · performance · architecture · UX). Full workspace
**lint 16/16 + tests 30/30 green** at every commit.

## Changes

### P0 — framework↔plugin isolation (discover by capability/dataSchema, never hardcode plugin IDs)
- **A1** persona loads via `persona-provider` capability (player-identity) — `loadActivePersona` no longer hardcodes `"player-identity"`.
- **A2** prompt-history rewrite via `prompt-history-rewriter` capability (branch-reply) — `buildProjectedPromptHistory` no longer hardcodes `"branch-reply"`.
- **A3** character blueprints discovered via `dataSchemas.{blueprints,characters}.acceptsWorldData`; deduped `world-character-blueprints` against the canonical import path; dropped the redundant hardcoded char-creator mirror.
- **A4** removed dead `branch-reply` block-type dispatch in the chat renderer + de-hardcoded the injected pluginId (branch-reply renders via the standard plugin-message surface).
- **A5** flow-viz uses neutral `priority-band-*` segment ids instead of mapping priority 500 → `narrator`.

### Performance
- MemoryStore `beginTx` shallow-copy instead of full `structuredClone` (+5 rollback regression tests).
- Snapshot payload N+1 fix + parallel state-entry queries.
- Web `SessionContext` split (state/actions) + chat list O(n²)→O(1)+memo.
- Chat rows skip off-screen layout/paint via `content-visibility: auto` (P1-E).

### UX / a11y
- Streaming scroll follow + "jump to latest", SSE reconnect indicator, start-game/resume loading lock.
- Global `prefers-reduced-motion`; form/boot/toast/export feedback.

### Cleanup
- Broke two apps/web barrel import cycles (asset-render, services/api) — madge: 0 cycles.
- Broke `test-runtime` cases↔runner type cycle.
- Moved `onlyBuiltDependencies` to `pnpm-workspace.yaml` (pnpm 10 ignored the old `pnpm` field).
- Security hardening: `keys.env` chmod 0600 + newline-injection guard.
- Docs: `docs/reference/plugins.md` capability sync; CLAUDE.md error-sanitiser pointer.

## Test plan

- [x] `pnpm lint` — 16/16
- [x] `pnpm test` — 30/30
- [x] `madge` — 0 circular deps in apps/web
- [ ] Visual (reviewer, live app): streaming scroll follow + jump-to-latest
- [ ] Visual: long-session scrollback stability
- [ ] Visual: branch-reply candidates render + accept/regenerate interaction (A4 removed dead path)
- [ ] Visual: per-turn execution timeline + asset sidebar still inline correctly

## Not addressed (upstream debt)
`@esbuild-kit/*` and `prebuild-install` deprecation warnings are deprecated across all versions and pulled by latest `drizzle-kit` / `better-sqlite3`; left as-is until upstream migrates.