### PR TITLE
feat: web-only (IndexedDB) public hosting hardening + Render blueprint fixes

### DIFF
--- a/apps/server/src/env.d.ts
+++ b/apps/server/src/env.d.ts
@@ -1,4 +1,4 @@
-import type { DataStore, MediaStore } from "@covel/store";
+import type { DataStore, MediaStore, StoreBackend } from "@covel/store";
 import type {
   PluginRegistry,
   LoadedRuntime,
@@ -46,6 +46,12 @@ type ActivatePluginLocalToolsFn = (pluginId: string) => Promise<void>;
 declare module "hono" {
   interface ContextVariableMap {
     store: DataStore;
+    /**
+     * Backend of the DataStore actually instantiated by `bootstrapApi()`.
+     * `memory` signals a local-mode deployment (frontend persists to browser
+     * IndexedDB; server-side sessions are transient sync copies).
+     */
+    storeBackend?: StoreBackend;
     stateManager: StateManager;
     eventBus: EventBus;
     pluginRegistry: PluginRegistry;

--- a/apps/server/src/routes/api/bootstrap.ts
+++ b/apps/server/src/routes/api/bootstrap.ts
@@ -402,6 +402,7 @@ export async function bootstrapApi(
 
   app.use("*", async (c, next) => {
     c.set("store", store);
+    c.set("storeBackend", config.storeBackend);
     c.set("stateManager", stateManager);
     c.set("eventBus", eventBus);
     c.set("pluginRegistry", registry);

--- a/apps/server/src/routes/api/session.ts
+++ b/apps/server/src/routes/api/session.ts
@@ -15,8 +15,14 @@
 
 import { randomUUID } from "node:crypto";
 import { Hono } from "hono";
+import { readRuntimeEnv } from "@covel/shared";
 import type { PluginRegistry } from "@covel/plugin-loader";
-import type { DataStore, MediaStore, SessionRecord } from "@covel/store";
+import type {
+  DataStore,
+  MediaStore,
+  SessionRecord,
+  StoreBackend,
+} from "@covel/store";
 import type { EventBus } from "@covel/events";
 import type { HookPipeline } from "@covel/runtime";
 import {
@@ -63,6 +69,7 @@ type Env = {
     mediaStore?: MediaStore;
     worldsDirs?: readonly string[];
     covelHome?: string;
+    storeBackend?: StoreBackend;
   };
 };
 
@@ -105,6 +112,21 @@ async function fireSessionEnd(
 
 // GET /sessions(?worldId=xxx)
 sessionRoutes.get("/", async (c) => {
+  // MemoryStore deployments serve local-mode (browser IndexedDB) frontends,
+  // which list sessions from IDB and never call this endpoint. Sessions that
+  // do exist server-side are transient copies synced up for turn execution —
+  // on a shared public host the only callers of this listing would be other
+  // players, so hide it. Dev / ENABLE_DEBUG_PAGE deployments keep it for the
+  // /debug tooling.
+  const env = readRuntimeEnv();
+  const hideSharedListing =
+    c.get("storeBackend") === "memory" &&
+    env.nodeEnv === "production" &&
+    !env.debugRoutes;
+  if (hideSharedListing) {
+    return c.json({ items: [] });
+  }
+
   const store = c.get("store");
   const worldId = c.req.query("worldId");
   const sessions = await store.listSessions();

--- a/apps/server/tests/api/session-listing-privacy.test.ts
+++ b/apps/server/tests/api/session-listing-privacy.test.ts
@@ -1,0 +1,110 @@
+/**
+ * GET /api/sessions privacy gate.
+ *
+ * MemoryStore deployments serve local-mode (browser IndexedDB) frontends,
+ * which never list sessions from the server — server-side sessions there are
+ * transient sync copies for turn execution. On a shared public host the
+ * listing must therefore be hidden, unless ENABLE_DEBUG_PAGE opts back in
+ * (dev tooling) or NODE_ENV is not production.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import {
+  createMemoryStore,
+  type DataStore,
+  type StoreBackend,
+} from "@covel/store";
+import { sessionRoutes } from "../../src/routes/api/session.js";
+
+function buildApp(store: DataStore, backend?: StoreBackend): Hono {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("store", store);
+    if (backend) {
+      c.set("storeBackend", backend);
+    }
+    await next();
+  });
+  app.route("/api/sessions", sessionRoutes);
+  return app;
+}
+
+async function seedSession(store: DataStore): Promise<void> {
+  await store.createSession({
+    id: "sess-privacy",
+    worldId: "cloudmere",
+    status: "active",
+    turnCount: 1,
+    preGameCompleted: [],
+    locale: "zh-CN",
+    activePlugins: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_DEBUG_PAGE = process.env.ENABLE_DEBUG_PAGE;
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+afterEach(() => {
+  restoreEnv("NODE_ENV", ORIGINAL_NODE_ENV);
+  restoreEnv("ENABLE_DEBUG_PAGE", ORIGINAL_DEBUG_PAGE);
+});
+
+async function listItems(app: Hono): Promise<unknown[]> {
+  const res = await app.request("/api/sessions");
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { items: unknown[] };
+  return body.items;
+}
+
+describe("GET /api/sessions listing privacy", () => {
+  it("hides the listing on memory backend in production", async () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.ENABLE_DEBUG_PAGE;
+    const store = createMemoryStore();
+    await seedSession(store);
+
+    const items = await listItems(buildApp(store, "memory"));
+    expect(items).toEqual([]);
+  });
+
+  it("keeps the listing when ENABLE_DEBUG_PAGE opts in", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.ENABLE_DEBUG_PAGE = "1";
+    const store = createMemoryStore();
+    await seedSession(store);
+
+    const items = await listItems(buildApp(store, "memory"));
+    expect(items).toHaveLength(1);
+  });
+
+  it("keeps the listing outside production (dev servers)", async () => {
+    process.env.NODE_ENV = "development";
+    delete process.env.ENABLE_DEBUG_PAGE;
+    const store = createMemoryStore();
+    await seedSession(store);
+
+    const items = await listItems(buildApp(store, "memory"));
+    expect(items).toHaveLength(1);
+  });
+
+  it("keeps the listing on persistent backends (remote mode)", async () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.ENABLE_DEBUG_PAGE;
+    const store = createMemoryStore();
+    await seedSession(store);
+
+    const items = await listItems(buildApp(store, "sqlite"));
+    expect(items).toHaveLength(1);
+  });
+});

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,9 +22,11 @@ COPY packages/context/package.json packages/context/
 COPY packages/create/package.json packages/create/
 COPY packages/events/package.json packages/events/
 COPY packages/memory/package.json packages/memory/
+COPY packages/plugin-handlers-utils/package.json packages/plugin-handlers-utils/
 COPY packages/plugin-loader/package.json packages/plugin-loader/
 COPY packages/plugin-test-utils/package.json packages/plugin-test-utils/
 COPY packages/runtime/package.json packages/runtime/
+COPY packages/settings/package.json packages/settings/
 COPY packages/shared/package.json packages/shared/
 COPY packages/state/package.json packages/state/
 COPY packages/store/package.json packages/store/
@@ -38,6 +40,8 @@ COPY plugins/character-blueprint/package.json plugins/character-blueprint/
 COPY plugins/character-presence/package.json plugins/character-presence/
 COPY plugins/chat-mode-narrator/package.json plugins/chat-mode-narrator/
 COPY plugins/codex/package.json plugins/codex/
+COPY plugins/cost-gate/package.json plugins/cost-gate/
+COPY plugins/director/package.json plugins/director/
 COPY plugins/guide/package.json plugins/guide/
 COPY plugins/living-world-rules/package.json plugins/living-world-rules/
 COPY plugins/memory/package.json plugins/memory/
@@ -47,6 +51,8 @@ COPY plugins/player-identity/package.json plugins/player-identity/
 COPY plugins/pregame/package.json plugins/pregame/
 COPY plugins/scene-cast/package.json plugins/scene-cast/
 COPY plugins/scene-prompts/package.json plugins/scene-prompts/
+COPY plugins/scene-stage/package.json plugins/scene-stage/
+COPY plugins/story-guard/package.json plugins/story-guard/
 COPY plugins/world-init/package.json plugins/world-init/
 
 # ── Stage 2a: Dev dependencies for the web build ──────────────────

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -857,6 +857,8 @@ Session 级 lorebook 词条的只读查看 + 启用/删除管理。Entries 由�
 
 列出所有游戏会话。支持 `?worldId=` 查询参数过滤。
 
+> **隐私门禁**：当服务器以 `STORE_BACKEND=memory` 运行（前端处于 local/IndexedDB 模式，服务器端 session 只是回合执行的临时同步副本）且 `NODE_ENV=production` 且未设置 `ENABLE_DEBUG_PAGE` 时，本端点固定返回 `{ "items": [] }` —— 公网共享部署下防止玩家互相枚举 session。local 模式前端从不调用此端点（列表读浏览器 IDB），故对产品功能无影响。
+
 **响应:**
 
 ```json

--- a/render.yaml
+++ b/render.yaml
@@ -1,9 +1,13 @@
 # Render Blueprint — one-click demo deployment (no PostgreSQL)
 # https://docs.render.com/infrastructure-as-code
 #
-# Data persists in the player's browser IndexedDB.
-# Server uses volatile MemoryStore — data is lost on sleep/restart,
-# but the frontend auto-syncs session context back when needed.
+# Data persists in the player's browser IndexedDB (STORE_BACKEND=memory
+# switches the frontend to local mode via /api/health). The server keeps
+# only volatile MemoryStore copies synced up for turn execution — lost on
+# sleep/restart, and never listed to other players (the session listing
+# endpoint is hidden in this mode). Provider API keys stay in the player's
+# browser and travel per-request via the X-Provider-Keys header; the server
+# never persists them.
 #
 # Deploy: connect this repo on Render Dashboard, or use the Deploy button.
 
@@ -14,9 +18,15 @@ services:
     dockerfilePath: ./docker/Dockerfile
     dockerContext: .
     plan: free
+    healthCheckPath: /api/health
     envVars:
       - key: NODE_ENV
         value: production
+      # Explicit — the default is sqlite, which would put every player's
+      # data in one shared server-side DB. memory ⇒ frontend local mode
+      # (browser IndexedDB), per-player isolation.
+      - key: STORE_BACKEND
+        value: memory
       - key: SERVE_STATIC
         value: "true"
       - key: STATIC_DIR
@@ -25,5 +35,5 @@ services:
         value: "3001"
       - key: DEPLOYMENT_TIER
         value: demo
-      # No STORE_BACKEND / DATABASE_URL → server uses MemoryStore
-      # All persistent data lives in the player's browser IndexedDB
+      - key: ENABLE_DEBUG_PAGE
+        value: "false"


### PR DESCRIPTION
## Summary

Prepares the pure-web deployment path (all player data in browser IndexedDB, hosted on Render) and closes the cross-player session enumeration hole on shared public hosts.

- **`GET /api/sessions` privacy gate** — when the server runs `STORE_BACKEND=memory` (frontend is in local/IDB mode), `NODE_ENV=production`, and `ENABLE_DEBUG_PAGE` is unset, the listing returns `{ items: [] }`. Local-mode frontends list sessions from IDB and never call this endpoint; server-side sessions in this mode are transient sync copies for turn execution, and the only public callers would be other players. Session detail routes stay reachable by ID (`{worldId}-{uuid8}`, enumeration-resistant).
- **`render.yaml`** — `STORE_BACKEND=memory` made explicit: the old comment claimed "no STORE_BACKEND → MemoryStore", but the actual default is `sqlite`, which would have put every player's data in one shared ephemeral DB and kept the frontend in remote mode. Also adds `healthCheckPath: /api/health` and `ENABLE_DEBUG_PAGE=false`.
- **`docker/Dockerfile`** — workspace manifest stage was stale: missing `packages/settings`, `packages/plugin-handlers-utils` and plugins `cost-gate` / `director` / `scene-stage` / `story-guard`, so `pnpm install --frozen-lockfile` failed and the Render/Docker build could not succeed. Lists now verified against the actual directories.
- **Docs** — `docs/reference/api.md` documents the listing gate.

Provider API keys were already safe for public hosting (browser localStorage → per-request `X-Provider-Keys` header, never persisted server-side); no change needed there.

## Test plan

- [x] New `apps/server/tests/api/session-listing-privacy.test.ts` (4 cases: hidden in prod+memory, visible with `ENABLE_DEBUG_PAGE`, visible in dev, visible on persistent backends)
- [x] `pnpm --filter @covel/server test` — 530/530 passed
- [x] `pnpm lint` — 18/18 tasks passed
- [x] Dockerfile manifest lists diffed against `packages/` and `plugins/` directories — exact match
- [ ] Deploy blueprint on Render and verify `/api/health` reports `frontendMode: local`