### PR TITLE
Release v0.0.13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: Build Desktop
 #   - manual dispatch     → optional tag/publish for ad-hoc reproductions.
 #
 # Primary distribution path is local builds (`pnpm build:electron`); CI is
-# the reproducible / signed path. macOS arm64 + Windows x64/arm64 —
+# the reproducible / signed path. macOS arm64 + Windows x64 —
 # Linux builds locally on its native OS.
 on:
   push:
@@ -141,7 +141,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: covel-electron-win
-          # nsis (x64 + arm64) and portable (x64) installers; cleanup-artifacts.mjs
+          # nsis and portable (x64) installers; cleanup-artifacts.mjs
           # already strips blockmaps and update-info yml.
           path: release/electron/*.exe
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **English** · [简体中文](./README.zh-CN.md)
 
-[![Version](https://img.shields.io/badge/version-v0.0.12-8b5cf6)](https://github.com/ackness/covel/releases/tag/v0.0.12)
+[![Version](https://img.shields.io/badge/version-v0.0.13-8b5cf6)](https://github.com/ackness/covel/releases/tag/v0.0.13)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Stage](https://img.shields.io/badge/stage-early--access-orange)]()
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ackness/covel)
@@ -13,7 +13,7 @@
 
 Covel is an AI RPG where the world keeps running between your turns: NPCs track how they feel about you, lore accumulates as you play, and memory carries the thread across the session. Every mechanic behind that is an **autonomous agent shipped as a plugin** — disable one, swap one, or write your own.
 
-> **Current public release: v0.0.12**, early access — APIs, data formats, and plugin frontmatter may change between versions. Prebuilt binaries target macOS Apple Silicon; other platforms build from source.
+> **Current public release: v0.0.13**, early access — APIs, data formats, and plugin frontmatter may change between versions. Prebuilt binaries target macOS Apple Silicon and Windows x64; other platforms build from source.
 
 ## Highlights
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 [English](./README.md) · **简体中文**
 
-[![Version](https://img.shields.io/badge/version-v0.0.12-8b5cf6)](https://github.com/ackness/covel/releases/tag/v0.0.12)
+[![Version](https://img.shields.io/badge/version-v0.0.13-8b5cf6)](https://github.com/ackness/covel/releases/tag/v0.0.13)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Stage](https://img.shields.io/badge/stage-early--access-orange)]()
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ackness/covel)
@@ -13,7 +13,7 @@
 
 Covel 是一款 AI 驱动的 RPG，回合之间世界仍在运转：NPC 记录着对你的态度、世界典籍随游玩积累、记忆贯穿整局。支撑这一切的每个机制都是一个**以插件形式分发的自主 agent** —— 禁用一个、替换一个，或者自己写一个。
 
-> **当前公开版本：v0.0.12**，早期阶段 —— API、数据格式、插件 frontmatter 可能随版本变化。官方预编译包面向 macOS Apple Silicon，其余平台从源码构建。
+> **当前公开版本：v0.0.13**，早期阶段 —— API、数据格式、插件 frontmatter 可能随版本变化。官方预编译包面向 macOS Apple Silicon 与 Windows x64，其余平台从源码构建。
 
 ## 亮点
 

--- a/apps/desktop/PACKAGING.md
+++ b/apps/desktop/PACKAGING.md
@@ -1,6 +1,6 @@
 # Packaging & Signing — Covel Desktop
 
-This document describes how to build signed, notarized Covel desktop artifacts. The official GitHub Release workflow currently publishes macOS Apple Silicon artifacts; the local electron-builder config can still build Windows and Linux artifacts on their native platforms.
+This document describes how to build signed, notarized Covel desktop artifacts. The official GitHub Release workflow publishes macOS Apple Silicon and Windows x64 artifacts; the local electron-builder config can still build Linux artifacts on its native platform.
 
 ## One-off prep
 

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -112,9 +112,14 @@ dmg:
 #   WIN_CSC_TIMESTAMP_SERVER — optional RFC 3161 timestamp URL
 win:
   icon: resources/icon.ico
+  # x64 only: staging/server/node_modules (extraResources) carries a
+  # better-sqlite3 rebuilt for the build host's arch, so an arm64 installer
+  # built on an x64 runner would ship an x64 addon the arm64 sidecar cannot
+  # load (ERR_DLOPEN_FAILED). Windows-on-ARM runs the x64 installer via
+  # emulation. Re-add arm64 only together with per-arch staging/rebuild.
   target:
     - target: nsis
-      arch: [x64, arm64]
+      arch: [x64]
     - target: portable
       arch: [x64]
   # electron-builder 26.x 起签名相关字段改到 signtoolOptions 下。

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/desktop",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "main": "dist/main.mjs",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/server",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "files": [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/web",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "deprecated": false,
   "type": "module",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,14 +4,19 @@ All notable changes to this project will be documented in this file. Follows [Ke
 
 ## [Unreleased]
 
+## [0.0.13] - 2026-07-10
+
+The Windows release. The dev environment (spawn shims, plugin loading, supervised `pnpm dev`) now works on Windows, and CI builds Windows installers alongside the macOS bundles on every tag. Public web-only (browser IndexedDB) deployments are hardened: the shared session listing is hidden and the Render blueprint pins the memory backend explicitly.
+
 ### Added
 
-- **Windows desktop CI.** `release.yml` gains a `build-electron-win` job (windows-latest): full desktop build with Electron-ABI native rebuild, staged-server smoke under Electron's Node mode, `electron-builder --win` (NSIS x64/arm64 + portable x64, unsigned until a cert is configured), and `.exe` artefacts attached to GitHub Releases alongside the macOS bundles.
+- **Windows desktop CI.** `release.yml` gains a `build-electron-win` job (windows-latest): full desktop build with Electron-ABI native rebuild, staged-server smoke under Electron's Node mode, `electron-builder --win` (NSIS + portable, x64, unsigned until a cert is configured), and `.exe` artefacts attached to GitHub Releases alongside the macOS bundles. Windows targets are x64-only: the staged server ships a better-sqlite3 rebuilt for the build host's arch, so an arm64 installer from an x64 runner would carry an addon the arm64 sidecar cannot load — Windows-on-ARM runs the x64 installer via emulation.
 
 ### Fixed
 
 - **Windows dev environment.** Dev scripts spawn through `cross-spawn` (resolves `pnpm.cmd`-style shims with correct cmd.exe quoting); plugin/runtime dynamic imports of absolute paths go through `pathToFileURL` so plugin loading works on Windows; `pnpm dev` launches web + server directly with supervised teardown; `--env-file-if-exists` tolerates a missing `.env` (raises the minimum Node to 22.9).
 - **Desktop staging smoke now exercises the Electron ABI.** The native rebuild runs before the smoke test and the staged server boots under `ELECTRON_RUN_AS_NODE`; a missing Electron binary fails the build instead of silently downgrading the check (`COVEL_SMOKE_HOST_NODE=1` opts into the weaker host-Node smoke).
+- **Public web-only hosting hardening.** On memory-backend production deploys without debug routes, `GET /api/session` returns an empty list — server-side sessions there are transient sync copies of browser-IndexedDB data, and the only callers of a shared listing would be other players. `render.yaml` pins `STORE_BACKEND=memory` explicitly (the sqlite default would pool every player's data in one shared DB), adds a health check, and disables the debug page; the Docker image regains the workspace manifests (`settings`, `plugin-handlers-utils`, and four plugins) missing from its dependency-install stage.
 
 ## [0.0.12] - 2026-07-06
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "covel",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ai-provider/package.json
+++ b/packages/ai-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/ai-provider",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/approval/package.json
+++ b/packages/approval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/approval",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/context",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/create",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/events",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/memory",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-handlers-utils/package.json
+++ b/packages/plugin-handlers-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-handlers-utils",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-loader/package.json
+++ b/packages/plugin-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-loader",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-test-utils/package.json
+++ b/packages/plugin-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-test-utils",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/runtime",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/settings",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/shared",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/state",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/store",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "private": true,
   "exports": {

--- a/packages/test-runtime/package.json
+++ b/packages/test-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/test-runtime",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/tools",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/plugins/branch-reply/package.json
+++ b/plugins/branch-reply/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-branch-reply",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/char-creator/package.json
+++ b/plugins/char-creator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-char-creator",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/character-blueprint/package.json
+++ b/plugins/character-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-character-blueprint",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/character-presence/package.json
+++ b/plugins/character-presence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-character-presence",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/chat-mode-narrator/package.json
+++ b/plugins/chat-mode-narrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-chat-mode-narrator",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/codex/package.json
+++ b/plugins/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-codex",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/cost-gate/package.json
+++ b/plugins/cost-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-cost-gate",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/director/package.json
+++ b/plugins/director/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-director",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/guide/package.json
+++ b/plugins/guide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-guide",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/living-world-rules/package.json
+++ b/plugins/living-world-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-living-world-rules",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/memory/package.json
+++ b/plugins/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-memory",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module"
 }

--- a/plugins/narrator/package.json
+++ b/plugins/narrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-narrator",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/npc-graph/package.json
+++ b/plugins/npc-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-npc-graph",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/player-identity/package.json
+++ b/plugins/player-identity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-player-identity",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/pregame/package.json
+++ b/plugins/pregame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-pregame",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/scene-cast/package.json
+++ b/plugins/scene-cast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-scene-cast",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/scene-prompts/package.json
+++ b/plugins/scene-prompts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-scene-prompts",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/scene-stage/package.json
+++ b/plugins/scene-stage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-scene-stage",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/story-guard/package.json
+++ b/plugins/story-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-story-guard",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/world-init/package.json
+++ b/plugins/world-init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-world-init",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Release v0.0.13

2 commits on top of the already-merged #13 / #14 content (this PR carries the release bump + a Windows CI correctness fix; the feature work itself landed via #13 and #14).

### Highlights

- **fix (1): Windows desktop CI targets x64 only.** The staged server bundles a better-sqlite3 rebuilt for the build host's arch (x64 runner), so the previously configured arm64 NSIS installer would ship an addon the arm64 Electron sidecar cannot load (`ERR_DLOPEN_FAILED`). Windows-on-ARM runs the x64 installer via emulation; arm64 returns only together with per-arch staging/rebuild.
- **chore (1): version bump 0.0.12 → 0.0.13** across all 40 workspace manifests, README badges/release links (now mentioning Windows x64 prebuilts), PACKAGING.md, lockfile, and the `## [0.0.13]` CHANGELOG section (CI extracts the release body from it) — covering Windows dev-environment fixes, Windows desktop CI, and public web-only hosting hardening from #13/#14.

### Verification

- [x] `pnpm release:preflight` 6/6 (incl. actionlint on the workflow)
- [x] `pnpm lint` 18/18 tasks
- [x] `pnpm test` 37/37 tasks
- [x] Diff scanned — no secrets / local paths

### Release

Merging this PR and pushing the annotated `v0.0.13` tag triggers `release.yml`: macOS arm64 (dmg/zip) + Windows x64 (NSIS/portable exe) builds, then auto-publishes the GitHub Release with the CHANGELOG section as body.

---

_中文摘要_：v0.0.13 发布 PR。内容为版本号全量 bump + 一个 Windows CI 修正（win 安装包收敛为 x64-only，原 arm64 目标会打出装载不了的 x64 native 模块）；功能本体（Windows 开发环境修复、Windows 桌面 CI、公开 Web 部署加固）已经由 #13/#14 合入。合并后打 v0.0.13 tag 触发 CI 构建 macOS + Windows 安装包并自动发布 Release。