### PR TITLE
fix: Windows portable exe overwrote the NSIS installer (artifact name collision)

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -131,6 +131,12 @@ win:
   # for published builds but allow unsigned locally via env.
   # publisherName: "Your Organization"  # uncomment once cert is in place
 
+# Distinct artifact name — nsis and portable otherwise both emit
+# ${productName}-electron-${version}-win-${arch}.exe and the portable build
+# (built second) silently overwrites the NSIS installer.
+portable:
+  artifactName: ${productName}-electron-${version}-${os}-${arch}-portable.${ext}
+
 nsis:
   oneClick: false
   perMachine: false


### PR DESCRIPTION
## Fix

`nsis` and `portable` targets both render the shared `artifactName` template to the identical `Covel-electron-<version>-win-x64.exe`; electron-builder builds portable second and silently overwrites the NSIS installer. The v0.0.13 publish (run 29065010623) therefore shipped only the portable exe — the actual installer (shortcuts, uninstaller) was lost.

Fix: portable target gets its own `artifactName` with a `-portable` suffix. Verified in the CI build log: `building target=nsis file=...win-x64.exe` followed by `building target=portable file=...win-x64.exe` (same path).

### Release

After merge, re-point the `v0.0.13` tag once more; the release job replaces the existing release in place (stale-release cleanup step).

---

_中文摘要_：NSIS 与 portable 两个 target 渲染出同名 exe，后构建的 portable 覆盖了安装器，首次发布只带了便携版。给 portable 加 `-portable` 后缀，重指 tag 重新发布。