### PR TITLE
Release v0.0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **English** · [简体中文](./README.zh-CN.md)
 
-[![Version](https://img.shields.io/badge/version-v0.0.13-8b5cf6)](https://github.com/ackness/covel/releases/tag/v0.0.13)
+[![Version](https://img.shields.io/badge/version-v0.0.14-8b5cf6)](https://github.com/ackness/covel/releases/tag/v0.0.14)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Stage](https://img.shields.io/badge/stage-early--access-orange)]()
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ackness/covel)
@@ -13,7 +13,7 @@
 
 Covel is an AI RPG where the world keeps running between your turns: NPCs track how they feel about you, lore accumulates as you play, and memory carries the thread across the session. Every mechanic behind that is an **autonomous agent shipped as a plugin** — disable one, swap one, or write your own.
 
-> **Current public release: v0.0.13**, early access — APIs, data formats, and plugin frontmatter may change between versions. Prebuilt binaries target macOS Apple Silicon and Windows x64; other platforms build from source.
+> **Current public release: v0.0.14**, early access — APIs, data formats, and plugin frontmatter may change between versions. Prebuilt binaries target macOS Apple Silicon and Windows x64; other platforms build from source.
 
 ## Highlights
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 [English](./README.md) · **简体中文**
 
-[![Version](https://img.shields.io/badge/version-v0.0.13-8b5cf6)](https://github.com/ackness/covel/releases/tag/v0.0.13)
+[![Version](https://img.shields.io/badge/version-v0.0.14-8b5cf6)](https://github.com/ackness/covel/releases/tag/v0.0.14)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Stage](https://img.shields.io/badge/stage-early--access-orange)]()
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ackness/covel)
@@ -13,7 +13,7 @@
 
 Covel 是一款 AI 驱动的 RPG，回合之间世界仍在运转：NPC 记录着对你的态度、世界典籍随游玩积累、记忆贯穿整局。支撑这一切的每个机制都是一个**以插件形式分发的自主 agent** —— 禁用一个、替换一个，或者自己写一个。
 
-> **当前公开版本：v0.0.13**，早期阶段 —— API、数据格式、插件 frontmatter 可能随版本变化。官方预编译包面向 macOS Apple Silicon 与 Windows x64，其余平台从源码构建。
+> **当前公开版本：v0.0.14**，早期阶段 —— API、数据格式、插件 frontmatter 可能随版本变化。官方预编译包面向 macOS Apple Silicon 与 Windows x64，其余平台从源码构建。
 
 ## 亮点
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/desktop",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "main": "dist/main.mjs",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/server",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "files": [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/web",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "deprecated": false,
   "type": "module",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file. Follows [Ke
 
 ## [Unreleased]
 
+## [0.0.14] - 2026-07-13
+
+The agent-core release. Server-side plugin registration converges into a single `entry` factory (`covel.registerTool / on / registerRpc / registerWires`), players can steer or abort a turn while the LLM is still streaming, and a full-codebase audit hardened the turn/snapshot/fork consistency boundaries: proposal commits are now atomic under the session lock, auto snapshots capture post-commit state, forks restore session lifecycle from the snapshot itself, and outbound plugin fetches pin DNS resolution against rebinding.
+
+### Added
+
+- **Unified PluginAPI (`entry`).** The four scattered server-side registration surfaces (local tools, hooks, RPC actions, media wires) converge into one factory declared via the new `entry` PLUGIN.md field — `export default function (covel) { ... }` with `covel.registerTool / on / registerRpc / registerWires` and `covel.toolkit`. Agent runtimes declare LLM tool visibility with the new `tools.plugin` name list. All 8 bundled plugins with server-side registrations migrated; legacy fields keep working for one release cycle with a per-plugin deprecation warning, and community entries still defer to activation (trust gating unchanged).
+- **Mid-turn player steering + abort.** `POST /api/sessions/:id/steer` merges queued player interjections into story runtimes' next LLM step (persisted to history); `POST /api/sessions/:id/abort` cuts the in-flight LLM stream immediately, is non-retriable, bypasses the streaming salvage path (no partial narrative is ever committed), and surfaces as `abortReason: "aborted-by-player"` on the existing `execution.completed` event. Both return 409 when no turn is active. The web composer stays usable during a turn — submit steers, a stop button aborts.
+- **Snapshot payload schemaVersion 2.** Snapshots now capture session lifecycle and runtime configuration (`status`, `turnCount`, `preGameCompleted`, `locale`, `activePlugins`, `presetId`, `runtimeModelOverrides`), so forking an old snapshot restores the session as it was at capture time instead of inheriting the parent's current scheduling state. V1 snapshots remain readable and fork with the previous parent-fallback behaviour.
+
+### Changed
+
+- **Agent loop layering.** All how-to-run derivation (tool defs, schema gate, model override chain, streaming gate, step/retry budgets, `requireToolUse`, `acceptsSteering`) converges into `buildAgentLoopPolicy()`; the loop's single delta outlet is extracted into `createDeltaForwarder`. The loop body is control flow only and independently instantiable — pinned by a direct loop-core test suite (trace/delta sequences, runtime-done stripping, maxSteps, streaming gates, steer/abort/salvage-bypass).
+
+### Fixed
+
+- **Turn commits are atomic under the session lock.** Player-input persistence, turn execution, proposal commit, `turnCount` sync and the auto snapshot now run inside a single `sessionLock.withLock` scope, so an overlapping same-session action can no longer read pre-commit state (stale-read / lost-update). A bounded PG advisory-lock acquire timeout surfaces as a coded, retryable 503 instead of a generic 500.
+- **Auto snapshots capture post-commit state.** Snapshot capture moved out of the turn finalizer (which ran before proposals committed) into the server pipeline after commit — forked sessions no longer inherit a turn's dialogue while missing that same turn's state, character and plugin-data writes.
+- **Manual snapshots and forks share the session lock**, so payload reads can no longer observe a mixed point-in-time while a turn is committing.
+- **Plugin uninstall honours the install privilege boundary.** `DELETE /api/plugins/:id` (which recursively deletes the plugin directory) now sits behind the same production opt-in / desktop bearer-token guard as install, instead of being callable by anyone who can reach the API.
+- **Outbound plugin fetches pin DNS resolution.** SSRF validation previously only checked the literal hostname; a public name resolving to a private/metadata address passed. `fetchWithRetry` now resolves and policy-checks addresses per attempt and pins the connection to the validated address via an undici dispatcher (DNS-rebinding defence).
+- **PR #18 review hardening.** Plugin tool-access allowlists only grant ownership after successful registration (tool-name collisions are rejected instead of leaving a dangling grant); the active turn registers inside the session lock so a queued action can no longer steal the steer/abort target; the web client clears its delta buffer and streaming placeholder on player abort (no ghost message).
+
 ## [0.0.13] - 2026-07-10
 
 The Windows release. The dev environment (spawn shims, plugin loading, supervised `pnpm dev`) now works on Windows, and CI builds Windows installers alongside the macOS bundles on every tag. Public web-only (browser IndexedDB) deployments are hardened: the shared session listing is hidden and the Render blueprint pins the memory backend explicitly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "covel",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ai-provider/package.json
+++ b/packages/ai-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/ai-provider",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/approval/package.json
+++ b/packages/approval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/approval",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/context",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/create",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/events",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/memory",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-handlers-utils/package.json
+++ b/packages/plugin-handlers-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-handlers-utils",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-loader/package.json
+++ b/packages/plugin-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-loader",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-test-utils/package.json
+++ b/packages/plugin-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-test-utils",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/runtime",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/settings",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/shared",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/state",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/store",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "private": true,
   "exports": {

--- a/packages/test-runtime/package.json
+++ b/packages/test-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/test-runtime",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/tools",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "exports": {

--- a/plugins/branch-reply/package.json
+++ b/plugins/branch-reply/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-branch-reply",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/char-creator/package.json
+++ b/plugins/char-creator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-char-creator",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/character-blueprint/package.json
+++ b/plugins/character-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-character-blueprint",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/character-presence/package.json
+++ b/plugins/character-presence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-character-presence",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/chat-mode-narrator/package.json
+++ b/plugins/chat-mode-narrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-chat-mode-narrator",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/codex/package.json
+++ b/plugins/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-codex",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/cost-gate/package.json
+++ b/plugins/cost-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-cost-gate",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/director/package.json
+++ b/plugins/director/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-director",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/guide/package.json
+++ b/plugins/guide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-guide",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/living-world-rules/package.json
+++ b/plugins/living-world-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-living-world-rules",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/memory/package.json
+++ b/plugins/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-memory",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module"
 }

--- a/plugins/narrator/package.json
+++ b/plugins/narrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-narrator",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/npc-graph/package.json
+++ b/plugins/npc-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-npc-graph",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/player-identity/package.json
+++ b/plugins/player-identity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-player-identity",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/pregame/package.json
+++ b/plugins/pregame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-pregame",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/scene-cast/package.json
+++ b/plugins/scene-cast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-scene-cast",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/scene-prompts/package.json
+++ b/plugins/scene-prompts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-scene-prompts",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/scene-stage/package.json
+++ b/plugins/scene-stage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-scene-stage",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/story-guard/package.json
+++ b/plugins/story-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-story-guard",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/world-init/package.json
+++ b/plugins/world-init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-world-init",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Release v0.0.14

1 release commit on top of main (which already contains PR #18 + PR #19, 10 commits since v0.0.13).

### Highlights

**feat (2)**
- **Unified PluginAPI (`entry`)** — local tools / hooks / RPC actions / media wires converge into one factory (`covel.registerTool / on / registerRpc / registerWires` + `covel.toolkit`); `tools.plugin` declares LLM visibility; 8 bundled plugins migrated; legacy fields deprecated for one cycle.
- **Mid-turn player steering + abort** — `POST /api/sessions/:id/steer` and `/:id/abort`; abort cuts the in-flight LLM stream with no partial narrative committed; the composer stays live during a turn.

**fix (3 commit groups)**
- **2026-07-11 audit findings A-01..A-06** — turn commit atomicity under the session lock (+ coded 503 on PG lock timeout), auto snapshot after commit, snapshot payload schemaVersion 2 with lifecycle capture for deterministic forks, plugin uninstall behind the install privilege guard, manual snapshot under the session lock, DNS-pinned SSRF defence.
- **PR #18 review hardening** — tool-access allowlist only granted after successful registration, turn-control registration race closed, abort ghost message cleared on web.
- **W4 hardening** — tool-name collisions rejected, steering merge order pinned.

**refactor (1)**
- **Agent loop layering** — `buildAgentLoopPolicy()` + `createDeltaForwarder`; loop body is control flow only, pinned by a direct loop-core test suite.

**docs (1)**
- Agent-core refactor roadmap spec with per-workstream implementation records.

### Verification

- [x] `pnpm release:preflight` — 6/6
- [x] `turbo lint` — 18/18
- [x] Package tests: ai-provider 216 · runtime 613 · server 553 · store 579 — all green
- [x] PG-gated tests against real pgvector container: store contract 144 · server integration 12 — all green
- [x] prettier check on changed files
- [x] CHANGELOG section `## [0.0.14]` present (release body is extracted from it by CI)
- [x] 40 package.json bumped + README/README.zh-CN badges and release links

### Release

Merging this PR (merge commit) then pushing the annotated tag `v0.0.14` triggers `release.yml`: macOS arm64 dmg/zip + Windows x64 NSIS/portable builds attached to the GitHub Release.

---

_中文摘要：agent-core 版本。插件服务端注册收敛为单一 entry 工厂；玩家可在回合进行中追加引导或中止（不落半截叙事）；全库审计修复 6 项 findings——回合提交纳入会话锁原子边界、自动快照后置到 commit 之后、快照 V2 捕获会话生命周期使 fork 可确定性恢复、插件卸载纳入安装特权守卫、SSRF 防护钳制 DNS 解析。_