### PR TITLE
Release v0.0.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **English** · [简体中文](./README.zh-CN.md)
 
-[![Version](https://img.shields.io/badge/version-v0.0.19-8b5cf6)](https://github.com/ackness/covel/releases/tag/v0.0.19)
+[![Version](https://img.shields.io/badge/version-v0.0.20-8b5cf6)](https://github.com/ackness/covel/releases/tag/v0.0.20)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Stage](https://img.shields.io/badge/stage-early--access-orange)](<>)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ackness/covel)
@@ -13,7 +13,7 @@
 
 Covel is an AI RPG where the world keeps running between your turns: NPCs track how they feel about you, lore accumulates as you play, and memory carries the thread across the session. Every mechanic behind that is an **autonomous agent shipped as a plugin** — disable one, swap one, or write your own.
 
-> **Current public release: v0.0.19**, early access — APIs, data formats, and plugin frontmatter may change between versions. Prebuilt binaries target macOS Apple Silicon and Windows x64; other platforms build from source.
+> **Current public release: v0.0.20**, early access — APIs, data formats, and plugin frontmatter may change between versions. Prebuilt binaries target macOS Apple Silicon and Windows x64; other platforms build from source.
 
 ## Highlights
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 [English](./README.md) · **简体中文**
 
-[![Version](https://img.shields.io/badge/version-v0.0.19-8b5cf6)](https://github.com/ackness/covel/releases/tag/v0.0.19)
+[![Version](https://img.shields.io/badge/version-v0.0.20-8b5cf6)](https://github.com/ackness/covel/releases/tag/v0.0.20)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Stage](https://img.shields.io/badge/stage-early--access-orange)](<>)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ackness/covel)
@@ -13,7 +13,7 @@
 
 Covel 是一款 AI 驱动的 RPG，回合之间世界仍在运转：NPC 记录着对你的态度、世界典籍随游玩积累、记忆贯穿整局。支撑这一切的每个机制都是一个**以插件形式分发的自主 agent** —— 禁用一个、替换一个，或者自己写一个。
 
-> **当前公开版本：v0.0.19**，早期阶段 —— API、数据格式、插件 frontmatter 可能随版本变化。官方预编译包面向 macOS Apple Silicon 与 Windows x64，其余平台从源码构建。
+> **当前公开版本：v0.0.20**，早期阶段 —— API、数据格式、插件 frontmatter 可能随版本变化。官方预编译包面向 macOS Apple Silicon 与 Windows x64，其余平台从源码构建。
 
 ## 亮点
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/desktop",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "main": "dist/main.mjs",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/server",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "files": [

--- a/apps/server/tests/api/chat-mode-http-e2e.test.ts
+++ b/apps/server/tests/api/chat-mode-http-e2e.test.ts
@@ -83,7 +83,9 @@ class ChatModeMockLLM implements LLMAdapter {
       };
     }
 
-    if (toolNames.includes("list-characters")) {
+    // `create-character` is the tracker's signature tool — the roster it used
+    // to read with `list-characters` is injected now, so that name is gone.
+    if (toolNames.includes("create-character")) {
       // char-creator/character-tracker — engine-agnostic since the upstream
       // gate became capability-based, so it
       // runs in dialogue mode too (it used to be permanently skipped by an

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/web",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "deprecated": false,
   "type": "module",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,18 @@ All notable changes to this project will be documented in this file. Follows [Ke
 
 ## [Unreleased]
 
-## [0.0.19] - 2026-07-25
+## [0.0.20] - 2026-07-25
+
+A follow-up to the cleanup release, from watching real sessions run. Three fixes, all found by reading traces rather than tests: a runtime could report success having done nothing, a hazard warning fired every turn regardless of the truth, and several runtimes were handed tools their own prompts told them never to call.
+
+### Fixed
+
+- **A bare `runtime-done` no longer satisfies `requireToolUse`.** A runtime whose whole declared job is to call a tool could finish as a success having called only the framework's loop terminator. Seen in production with `scene-prompts`: the model answered with prose, the gate nudged it once, and the model replied by calling `runtime-done` with the reason "完成 scene prompts 生成" — the actual work tool was never called. The turn reported success in 47.6s and the player got an empty quick-reply panel behind a green check. Two paths let it through: the gate counted any successful call, terminator included, and the runtime-done early exit breaks the loop _before_ the gate runs. Both now require a business tool call, and an unmet contract finalizes as `failed` with a diagnostic instead of an empty success.
+- **UI effects hazards are reported per slot, not per plugin.** Any manifest declaring a `ui` block was credited with writing `ui:*`, so every pair of UI-declaring runtimes in a DAG layer was flagged — nine warnings in a three-turn session, all false: a right-panel plugin cannot overwrite a message block. `EffectResource` now admits `ui:<slot>` and the derivation emits one key per declared slot. `ui:*` still wildcard-matches them, so an explicit declaration keeps its meaning, and two plugins that really do share a surface still hazard.
+
+### Changed
+
+- **Runtimes no longer receive tools their prompts forbid.** Five declarations were paid for twice — once in the tool schema on every LLM call, once in the prompt text spent forbidding them. `character-tracker` dropped `list-characters` (its roster is injected as `<existing-characters>`), both image `prompt-generator` runtimes dropped `plugin-data-list` (they inject the `prompts` namespace), and `world-init/schema-gen` dropped `plugin-data-get` / `plugin-data-list` (it writes during setup and never reads back). `get-character` and `list-npc-graph` stay: unlike the others they are the documented escape hatch for a truncated snapshot, and a live session confirmed `get-character` being used exactly that way. `extractor`'s guidance, which said "**无需**调用" in bold and then described when to call it eight lines later, is now one instruction.
 
 The cleanup release, following a full audit of the core framework. Nothing here adds capability; it removes surface that was declared but never honoured, and closes the security gaps that hid behind it.
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -454,6 +454,8 @@ Updated npc "苏婉" (char-abc123) → v2.
 
 列出本 session 所有角色（session 作用域，跨插件可见）。输出是**紧凑文本列表**，一行一个角色，包含 id / 名字 / 类型 / 版本 / 简短描述 —— 方便 LLM 快速对齐已知人物，需要完整属性时再单独调用 `get-character`。
 
+> **当前无捆绑插件声明它。** `character-tracker` 曾经声明过，但它的角色名册是在构建 prompt 时通过 `input.inject` 注入的（`<existing-characters>`），拿工具再查一遍是多余的往返。需要名册的第三方插件仍可声明；插件自己已经注入名册时，改用 `get-character` 处理"摘要不够、要看完整属性"的场景。
+
 **排序算法**：主键 `version desc`（版本越高 = 被交互次数越多 = 频率越高），次键 `updatedAt desc`（频率相同时最近 turn 的优先）。
 
 | 参数 | 类型 | 必需 | 描述                                |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "covel",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ai-provider/package.json
+++ b/packages/ai-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/ai-provider",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/approval/package.json
+++ b/packages/approval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/approval",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/context",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/create",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/events",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/memory",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-handlers-utils/package.json
+++ b/packages/plugin-handlers-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-handlers-utils",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-loader/package.json
+++ b/packages/plugin-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-loader",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-test-utils/package.json
+++ b/packages/plugin-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-test-utils",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/runtime",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/runtime/src/agent-loop/turn-agent-runtime.ts
+++ b/packages/runtime/src/agent-loop/turn-agent-runtime.ts
@@ -291,6 +291,7 @@ export async function executeAgentRuntime({
     stoppedWithResponse,
     effectiveMaxSteps,
     deadline,
+    requiredToolUseUnmet,
   } = toolLoop;
 
   // Shared PostRuntime-hook opts for every terminal path of this runtime.
@@ -322,6 +323,29 @@ export async function executeAgentRuntime({
         maxSteps: effectiveMaxSteps,
         failedToolCalls,
       }),
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  // `requireToolUse` unmet: the runtime declared that calling a tool IS its
+  // job, and it never did — the loop already nudged it once and released so a
+  // stubborn model cannot wedge the turn. Reporting success here would hand the
+  // player an empty panel behind a green check, with nothing in the trace to
+  // explain it, so fail with a diagnostic instead. Whatever prose the model
+  // produced is not this runtime's contract and is deliberately dropped.
+  if (requiredToolUseUnmet) {
+    return finalizeFailure({
+      pluginId: manifest.pluginId,
+      runtimeId: manifest.name,
+      runId,
+      turnId: input.turnId,
+      status: "failed",
+      output: null,
+      toolCalls: collectedToolCalls,
+      durationMs: Date.now() - startTime,
+      error:
+        `${manifest.name} declares requireToolUse but finished without calling a business tool ` +
+        `(a bare \`runtime-done\` does not count). The model answered with prose instead of doing the work.`,
       timestamp: new Date().toISOString(),
     });
   }

--- a/packages/runtime/src/agent-loop/turn-agent-tool-loop.ts
+++ b/packages/runtime/src/agent-loop/turn-agent-tool-loop.ts
@@ -53,6 +53,12 @@ export interface AgentToolLoopCompleted {
   readonly stoppedWithResponse: boolean;
   readonly effectiveMaxSteps: number;
   readonly deadline: number;
+  /**
+   * True when the runtime declared `requireToolUse` but finished without ever
+   * executing a business tool, even after the corrective nudge. The loop
+   * releases rather than wedging; the caller decides the outcome.
+   */
+  readonly requiredToolUseUnmet: boolean;
 }
 
 export type AgentToolLoopResult = AgentToolLoopCompleted | RuntimeResult;
@@ -116,6 +122,16 @@ export async function runAgentToolLoop({
     ...(initialState?.collectedToolCalls ?? []),
   ];
   const executedToolCalls: ExecutedToolCallState[] = [];
+  // Work done before a suspension lives in the seeded `collectedToolCalls`
+  // only — `executedToolCalls` always starts empty — so the requireToolUse
+  // gate below must count it, or a resumed runtime that already called its
+  // tool would be judged as having done nothing.
+  const seededBusinessWork = (initialState?.collectedToolCalls ?? []).some(
+    (c) => c.toolName !== "runtime-done",
+  );
+  // Set when `requireToolUse` released a runtime that never did business
+  // work — the caller turns it into a failure rather than an empty success.
+  let requiredToolUseUnmet = false;
   const failedToolCalls: FailedToolCallState[] = [];
   const pendingProposals: Proposal[] = [
     ...(initialState?.pendingProposals ?? []),
@@ -508,6 +524,14 @@ export async function runAgentToolLoop({
         );
         collectedToolCalls.length = 0;
         collectedToolCalls.push(...businessCalls);
+        // A `requireToolUse` runtime can reach here having called nothing but
+        // the terminator — a nudged model will do exactly that to satisfy
+        // "call the declared tools". This exit runs before the gate below, so
+        // record the unmet contract here or the runtime finishes as an empty
+        // success.
+        if (requireToolUse && businessCalls.length === 0) {
+          requiredToolUseUnmet = true;
+        }
         // Preserve streamed / captured prose from earlier steps or this
         // step's response.content. Without this guard a story runtime that
         // interleaves narrative prose + tool calls + runtime-done would lose
@@ -555,12 +579,23 @@ export async function runAgentToolLoop({
     }
 
     // requireToolUse gate: a runtime whose whole job is to call a tool has
-    // drifted into free-form prose (zero tool calls, nothing executed). Nudge
-    // it back once with a corrective system message; on a second bare finish
-    // release it (maxSteps still bounds the loop) so a stubborn model cannot
-    // wedge the runtime. Only fires when no tool ever executed successfully —
+    // drifted into free-form prose. Nudge it back once with a corrective
+    // system message; on a second bare finish release it (maxSteps still
+    // bounds the loop) so a stubborn model cannot wedge the runtime, but mark
+    // the contract unmet so the caller can fail honestly instead of reporting
+    // an empty success. Only fires when no BUSINESS tool ever executed —
     // a runtime that did its work and then narrated is left alone.
-    if (requireToolUse && !executedToolCalls.some((c) => c.success)) {
+    //
+    // `runtime-done` does not count. It is the framework's loop terminator,
+    // and a nudged model will happily call it alone to satisfy "call the
+    // declared tools" while doing no work at all — observed in the wild with
+    // scene-prompts, which reported success with zero prompts generated.
+    const didBusinessToolWork =
+      seededBusinessWork ||
+      executedToolCalls.some(
+        (c) => c.success && !isRuntimeDoneSentinel(c.result),
+      );
+    if (requireToolUse && !didBusinessToolWork) {
       if (noToolCallCorrections === 0) {
         noToolCallCorrections++;
         console.warn(
@@ -575,8 +610,9 @@ export async function runAgentToolLoop({
         continue;
       }
       console.warn(
-        `[runtime-retry] ${manifest.name} reason=no-tool-call cause=still no tool call after correction; releasing`,
+        `[runtime-retry] ${manifest.name} reason=no-tool-call cause=still no business tool call after correction; releasing`,
       );
+      requiredToolUseUnmet = true;
     }
 
     // Late steering: an interjection that arrived while THIS response
@@ -621,5 +657,6 @@ export async function runAgentToolLoop({
     stoppedWithResponse,
     effectiveMaxSteps,
     deadline,
+    requiredToolUseUnmet,
   };
 }

--- a/packages/runtime/src/schedule/effects.ts
+++ b/packages/runtime/src/schedule/effects.ts
@@ -110,7 +110,14 @@ export function deriveEffects(manifest: RuntimeManifest): RuntimeEffects {
   // outputKind: story runtimes write the narrative stream. Declared UI panels
   // imply ui writes (conservative — better over-declared than a missed hazard).
   if (manifest.outputKind === "story") writes.add("narrative:*");
-  if (manifest.ui) writes.add("ui:*");
+  // One key per declared UI slot, not a blanket `ui:*`. Two plugins that
+  // render into different surfaces (a right-panel vs a message block) never
+  // collide, and reporting them as a hazard every turn buries the pairs that
+  // genuinely share a surface. `ui:*` still wildcard-matches these, so an
+  // explicit `effects.writes: ["ui:*"]` keeps its old meaning.
+  for (const slot of Object.keys(manifest.ui ?? {})) {
+    writes.add(`ui:${slot}` as EffectResource);
+  }
 
   // Explicit `effects` is UNIONed with the derivation (v1 rule): an author may
   // ADD or tighten reads+writes but can never REMOVE a derived resource, so a

--- a/packages/runtime/tests/core-plugin-manifest-contract.test.ts
+++ b/packages/runtime/tests/core-plugin-manifest-contract.test.ts
@@ -68,10 +68,10 @@ describe("core plugin manifest contract", () => {
       "set-world-schema",
       "set-world-entries-batch",
     ]);
-    expect(schemaGen.tools?.builtin).toEqual([
-      "plugin-data-get",
-      "plugin-data-list",
-    ]);
+    // schema-gen writes the world schema during setup; it has no reason to
+    // read its own plugin-data back, and its prompt never mentioned the read
+    // tools it used to declare.
+    expect(schemaGen.tools?.builtin).toBeUndefined();
 
     expect(playerInit).toMatchObject({
       pluginType: "core-plugin",

--- a/packages/runtime/tests/effects-derivation.test.ts
+++ b/packages/runtime/tests/effects-derivation.test.ts
@@ -147,11 +147,41 @@ describe("deriveEffects — builtin tool mapping table", () => {
     expect(asSet(noTopics.writes)).toEqual(["event:*"]);
   });
 
-  it("derives narrative:* from outputKind story and ui:* from a declared ui block", () => {
+  it("derives narrative:* from outputKind story and one key per declared ui slot", () => {
     const e = deriveEffects(
       manifest({ outputKind: "story", ui: { right: "./ui.json" } as never }),
     );
-    expect(asSet(e.writes)).toEqual(["narrative:*", "ui:*"]);
+    expect(asSet(e.writes)).toEqual(["narrative:*", "ui:right"]);
+  });
+
+  it("keeps ui slots apart so different surfaces do not hazard", () => {
+    // Observed as noise in production: a right-panel plugin and two
+    // message-block plugins were reported as a same-layer hazard every turn
+    // purely because each declared *some* UI. They cannot overwrite one
+    // another — different surfaces entirely.
+    const panel = deriveEffects(
+      manifest({ ui: { right: "./panel.json" } as never }),
+    );
+    const block = deriveEffects(
+      manifest({ ui: { message: "./block.json" } as never }),
+    );
+    const otherBlock = deriveEffects(
+      manifest({ ui: { message: "./other.json" } as never }),
+    );
+
+    expect(effectsHazard(panel, block)).toBe(false);
+    // Same surface still hazards — the signal that is worth keeping.
+    expect(effectsHazard(block, otherBlock)).toBe(true);
+  });
+
+  it("an explicit ui:* declaration still covers every slot", () => {
+    const wildcard = deriveEffects(
+      manifest({ effects: { writes: ["ui:*"] } } as never),
+    );
+    const block = deriveEffects(
+      manifest({ ui: { message: "./block.json" } as never }),
+    );
+    expect(effectsHazard(wildcard, block)).toBe(true);
   });
 
   it("derives an empty set for an agent with no declared surfaces (no unknown:* injected)", () => {

--- a/packages/runtime/tests/require-tool-use.test.ts
+++ b/packages/runtime/tests/require-tool-use.test.ts
@@ -11,7 +11,11 @@ import { describe, it, expect, vi } from "vitest";
 import type { RuntimeManifest, TurnInput } from "@covel/shared";
 import { createMemoryStore } from "@covel/store";
 import type { DataStore } from "@covel/store";
-import { createEmitEventTool, type EventDirectoryLike } from "@covel/tools";
+import {
+  createEmitEventTool,
+  runtimeDoneTool,
+  type EventDirectoryLike,
+} from "@covel/tools";
 import { executeTurn } from "../src/turn-executor/turn-executor.js";
 import type { TurnExecutorDeps } from "../src/turn-executor/turn-executor.js";
 import { createToolExecutor } from "../src/agent-loop/tool-executor.js";
@@ -61,8 +65,13 @@ function manifest(overrides?: Partial<RuntimeManifest>): RuntimeManifest {
 
 function toolExecutor(store: DataStore) {
   return createToolExecutor({
-    findTool: (name) =>
-      name === "emit-event" ? createEmitEventTool({ directory }) : undefined,
+    findTool: (name) => {
+      if (name === "emit-event") return createEmitEventTool({ directory });
+      // The gate must treat this as "no work done", so the harness has to be
+      // able to resolve it — otherwise the call fails for the wrong reason.
+      if (name === runtimeDoneTool.name) return runtimeDoneTool;
+      return undefined;
+    },
     store,
   });
 }
@@ -108,6 +117,34 @@ class ScriptedLLM implements LLMAdapter {
 // gets English.
 const CORRECTION = "You finished without calling any tool";
 const CORRECTION_ZH = "你没有调用任何工具就结束了";
+
+/** Answers the corrective nudge by calling only the loop terminator. */
+class DoneOnlyLLM implements LLMAdapter {
+  step = 0;
+  async generate(): Promise<LLMResponse> {
+    this.step++;
+    if (this.step === 1) {
+      return {
+        content: "The corridor stretches on and the story continues.",
+        toolCalls: [],
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      };
+    }
+    return {
+      content: null,
+      toolCalls: [
+        {
+          id: `tc-done-${this.step}`,
+          name: "runtime-done",
+          arguments: JSON.stringify({ reason: "all set" }),
+        },
+      ],
+      finishReason: "tool_calls",
+      usage: { inputTokens: 10, outputTokens: 5 },
+    };
+  }
+}
 
 describe("requireToolUse gate", () => {
   it("injects one correction then succeeds when the retry calls the tool", async () => {
@@ -170,7 +207,7 @@ describe("requireToolUse gate", () => {
     ).toBe(true);
   });
 
-  it("releases with a warn when the retry still calls no tool", async () => {
+  it("releases with a warn and fails when the retry still calls no tool", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
       const store = await mainLoopStore("sess-2");
@@ -196,10 +233,47 @@ describe("requireToolUse gate", () => {
           String(c[0]).includes("reason=no-tool-call"),
         ),
       ).toBe(true);
+      // Released, but NOT reported as success: the runtime's whole declared
+      // job is to call a tool, and it never did. An empty success would hand
+      // the player a blank panel behind a green check.
       const res = result.runtimeResults.find(
         (r) => r.runtimeId === "plug/gated",
       );
-      expect(res?.status).toBe("success");
+      expect(res?.status).toBe("failed");
+      expect(res?.error).toContain("requireToolUse");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("a bare runtime-done does not satisfy the gate", async () => {
+    // Observed in the wild: nudged with "call the declared tools", the model
+    // called only the framework's loop terminator and did no work. The gate
+    // counted it as a successful tool call, so the runtime reported success
+    // with zero output — a green check over an empty panel.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const store = await mainLoopStore("sess-done");
+      const llm = new DoneOnlyLLM();
+      const deps: TurnExecutorDeps = {
+        loadRuntime: async (m) => ({ manifest: m, promptTemplate: "prompt" }),
+        llm,
+        store,
+        toolExecutor: toolExecutor(store),
+      };
+
+      const result = await executeTurn(
+        makeTurnInput({ sessionId: "sess-done" }),
+        [manifest({ requireToolUse: true })],
+        deps,
+        { maxSteps: 5 },
+      );
+
+      const res = result.runtimeResults.find(
+        (r) => r.runtimeId === "plug/gated",
+      );
+      expect(res?.status).toBe("failed");
+      expect(res?.error).toContain("requireToolUse");
     } finally {
       warn.mockRestore();
     }

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/settings",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/shared",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/shared/src/types/runtime-scheduling.ts
+++ b/packages/shared/src/types/runtime-scheduling.ts
@@ -149,7 +149,7 @@ export type EffectResource =
   | "media:*"
   | "working-memory:*"
   | "lorebook:*"
-  | "ui:*"
+  | `ui:${string}`
   | "interaction:*"
   | "unknown:*"
   | `plugin-data:self:${string}`

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/state",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/store",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "private": true,
   "exports": {

--- a/packages/test-runtime/package.json
+++ b/packages/test-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/test-runtime",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/tools",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "exports": {

--- a/plugins/branch-reply/package.json
+++ b/plugins/branch-reply/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-branch-reply",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/char-creator/package.json
+++ b/plugins/char-creator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-char-creator",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/char-creator/runtimes/character-tracker/PLUGIN.en.md
+++ b/plugins/char-creator/runtimes/character-tracker/PLUGIN.en.md
@@ -7,7 +7,7 @@ postHistory:
   role: system
   content: |
     Runtime workflow:
-    - The existing roster is in the `<existing-characters>` block, injected automatically at prompt-build time (one row per character: `- <id> | <updated-at> | <snapshot>`). Do NOT call list-characters.
+    - The existing roster is in the `<existing-characters>` block, injected automatically at prompt-build time (one row per character: `- <id> | <updated-at> | <snapshot>`).
     - When a new character or state change appears, call `create-character` / `update-character` (use the id from `<existing-characters>` for updates)
     - Only when you need a character's full attributes before deciding how to change them, call `get-character` on demand
     - When nothing changed, do NOT call create/update
@@ -28,7 +28,7 @@ The world's character attribute definitions ship with the **`fields` parameter s
 
 ### Step 1: review the existing roster (auto-injected, no tool needed)
 
-The existing roster is in the `<existing-characters>` block at the end of the prompt, injected by the framework at prompt-build time. You do **not** need to call `list-characters`. Each row looks like:
+The existing roster is in the `<existing-characters>` block at the end of the prompt, injected by the framework at prompt-build time. Each row looks like:
 
 ```
 - char-abc | 2026-07-23T10:00:00Z | {"id":"char-abc","name":"Su Wan","type":"npc","description":"Azure Duckweed outer-sect head disciple, senior sister",...}
@@ -76,7 +76,7 @@ Read `<narrator-output>` and identify:
 
 ### Hard rules
 
-- **Read `<existing-characters>` first** (already injected), then decide whether to create/update; you do not need to call list-characters
+- **Read `<existing-characters>` first** (already injected), then decide whether to create/update
 - **Only record changes the narrative states explicitly** — no guessing, no embellishment
 - **Never call `create-character` twice for the same character** (different descriptions don't justify a duplicate — it's still the same person)
 - **Never mutate player character attributes** unless the narrative explicitly describes an injury, growth, etc.

--- a/plugins/char-creator/runtimes/character-tracker/PLUGIN.md
+++ b/plugins/char-creator/runtimes/character-tracker/PLUGIN.md
@@ -38,8 +38,8 @@ input:
       field: narrativeOutput
       as: "<narrator-output>"
     # Existing roster injected at prompt-build time (own plugin_data[characters],
-    # keyed by character id). Removes the mandatory per-turn list-characters
-    # round-trip — same zero-cost pattern codex uses for its entries.
+    # keyed by character id) — a zero-cost read that replaces a per-turn
+    # roster tool call, the same pattern codex uses for its entries.
     - kind: plugin-data
       namespace: characters
       as: "<existing-characters>"
@@ -49,7 +49,6 @@ tools:
   builtin:
     - create-character
     - update-character
-    - list-characters
     - get-character
 dataSchemas:
   characters:
@@ -61,7 +60,7 @@ postHistory:
   role: system
   content: |
     本 runtime 工作流：
-    - 现有角色见 `<existing-characters>` 块（由框架在 prompt 构建时自动注入，每行 `- <id> | <更新时间> | <角色快照>`，无需调用 list-characters）
+    - 现有角色见 `<existing-characters>` 块（框架自动注入，每行 `- <id> | <更新时间> | <角色快照>`）
     - 有新角色或状态变化时，调用 `create-character` / `update-character`（update 用 `<existing-characters>` 里的 id）
     - 需要某角色的完整属性再决定如何改时，才按需调用 `get-character`
     - 没有变化时，不调用 create/update
@@ -82,7 +81,7 @@ postHistory:
 
 ### 第 1 步：查看现有角色概览（已自动注入，无需工具）
 
-现有角色列表在 prompt 末尾的 `<existing-characters>` 块中，由框架在构建 prompt 时自动注入，**不需要**调用 `list-characters`。每行格式为：
+现有角色列表在 prompt 末尾的 `<existing-characters>` 块中，由框架在构建 prompt 时自动注入。每行格式为：
 
 ```
 - char-abc | 2026-07-23T10:00:00Z | {"id":"char-abc","name":"苏婉","type":"npc","description":"青萍宗外门首席弟子，师姐",...}
@@ -130,7 +129,7 @@ postHistory:
 
 ### 硬规则
 
-- **先看 `<existing-characters>`**（已自动注入），再决定是否 create/update；不需要调用 list-characters
+- **先看 `<existing-characters>`**（已自动注入），再决定是否 create/update
 - **只处理叙事中明确出现的变化**，不要推测或发挥
 - **不要对同一角色连续调用 create-character**（即便是不同描述 —— 那是同一个人）
 - **不要修改玩家角色属性**，除非叙事明确描述了玩家受伤、成长等

--- a/plugins/char-creator/tests/char-creator.test.js
+++ b/plugins/char-creator/tests/char-creator.test.js
@@ -124,13 +124,25 @@ describe("char-creator plugin", () => {
       expect(manifest.stage).toBe("post-turn");
     });
 
-    it("declares the full character management tool suite", () => {
+    it("declares the write tools plus the on-demand detail read", () => {
       expect(manifest.tools?.builtin).toEqual(
         expect.arrayContaining([
           "create-character",
           "update-character",
-          "list-characters",
           "get-character",
+        ]),
+      );
+    });
+
+    it("does not declare list-characters — the roster is injected", () => {
+      // `<existing-characters>` is injected at prompt-build time, so a roster
+      // tool would be a round-trip the runtime is told never to make. Handing
+      // the model a tool its own prompt forbids costs tokens and invites a
+      // detour; `get-character` remains for the truncated-snapshot case.
+      expect(manifest.tools?.builtin).not.toContain("list-characters");
+      expect(manifest.input?.inject).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ namespace: "characters" }),
         ]),
       );
     });

--- a/plugins/character-blueprint/package.json
+++ b/plugins/character-blueprint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-character-blueprint",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/character-presence/package.json
+++ b/plugins/character-presence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-character-presence",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/chat-mode-narrator/package.json
+++ b/plugins/chat-mode-narrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-chat-mode-narrator",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/codex/package.json
+++ b/plugins/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-codex",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/cost-gate/package.json
+++ b/plugins/cost-gate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-cost-gate",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/dashscope-image-gen/package.json
+++ b/plugins/dashscope-image-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-dashscope-image-gen",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "description": "DashScope (Aliyun) image generation — manual-triggered two-stage pipeline: LLM-crafted prompt → wan2.x image model.",

--- a/plugins/dashscope-image-gen/runtimes/prompt-generator/PLUGIN.md
+++ b/plugins/dashscope-image-gen/runtimes/prompt-generator/PLUGIN.md
@@ -24,7 +24,6 @@ trigger:
   type: manual
 tools:
   builtin:
-    - plugin-data-list
     - plugin-data-set
 input:
   inject:

--- a/plugins/director/package.json
+++ b/plugins/director/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-director",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/guide/package.json
+++ b/plugins/guide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-guide",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/living-world-rules/package.json
+++ b/plugins/living-world-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-living-world-rules",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/memory/package.json
+++ b/plugins/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-memory",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module"
 }

--- a/plugins/mimo-tts/package.json
+++ b/plugins/mimo-tts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-mimo-tts",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "description": "Xiaomi MiMo TTS — speak narrator output as voice (auto + manual), persisted as MediaRef, replayable from a per-turn audio tab.",

--- a/plugins/narrator/package.json
+++ b/plugins/narrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-narrator",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/npc-graph/package.json
+++ b/plugins/npc-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-npc-graph",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/npc-graph/runtimes/extractor/PLUGIN.md
+++ b/plugins/npc-graph/runtimes/extractor/PLUGIN.md
@@ -66,7 +66,7 @@ postHistory:
   role: system
   content: |
     本 runtime 工作流：
-    - 已有节点见 `<existing-npcs>`、已有关系见 `<existing-relations>`（框架构建 prompt 时自动注入，无需调用 list-npc-graph）
+    - 已有节点见 `<existing-npcs>`、已有关系见 `<existing-relations>`（框架构建 prompt 时自动注入，直接读）
     - 有新节点或新关系时，调用一次 `upsert-npc-graph`（按 name 提交，工具内部映射 id）
     - 没有显著人物互动时，不调用 `upsert-npc-graph`
     - 完成（或决定不更新）后，立即调用 `runtime-done` 结束
@@ -78,14 +78,14 @@ postHistory:
 
 本轮叙事在 prompt 末尾的 `<narrator-output>` 块中（由框架 `input.inject` 自动注入，正文不再重复内联）。
 
-## 已有图谱（已自动注入，无需工具）
+## 已有图谱（已自动注入）
 
-本会话已登记的节点与关系在 prompt 末尾自动注入，**无需**调用 `list-npc-graph`：
+本会话已登记的节点与关系在 prompt 末尾自动注入，常规判断**直接读它就够**：
 
 - `<existing-npcs>`：已有节点，每行 `- <节点id> | <更新时间> | {name, type, summary, ...}`。按 **name** 比对避免重复创建（工具也按 name 去重）。
 - `<existing-relations>`：已有关系，每行 `- <边id> | <更新时间> | {source, target, relation, strength, fact, validAt, invalidAt?}`。`source`/`target` 是节点 id；带 `invalidAt` 的是已失效的旧版本，忽略。摘要里的 `fact` 可能被截断——只用来判断"这条关系是否已登记过"，据此避免重复记录未变化的关系。
 
-极少数需要某关系完整 fact 才能判断是否变化时，才按需调用 `list-npc-graph`。
+`list-npc-graph` 只有一个用途：注入的 `fact` 被截断、而你必须看到完整内容才能判断关系是否变化时，按边 id 取。除此之外不要调用它——注入的摘要已经覆盖了绝大多数判断。
 
 ## 本体约束
 

--- a/plugins/openai-image-gen/package.json
+++ b/plugins/openai-image-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-openai-image-gen",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "description": "OpenAI-compatible image generation via the framework's unified ctx.images pipeline, works with OpenAI and any OpenAI-compatible third-party (gpt-image-2 default).",

--- a/plugins/openai-image-gen/runtimes/prompt-generator/PLUGIN.md
+++ b/plugins/openai-image-gen/runtimes/prompt-generator/PLUGIN.md
@@ -19,7 +19,6 @@ trigger:
   type: manual
 tools:
   builtin:
-    - plugin-data-list
     - plugin-data-set
 input:
   inject:

--- a/plugins/player-identity/package.json
+++ b/plugins/player-identity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-player-identity",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/pregame/package.json
+++ b/plugins/pregame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-pregame",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/scene-cast/package.json
+++ b/plugins/scene-cast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-scene-cast",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/scene-prompts/package.json
+++ b/plugins/scene-prompts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-scene-prompts",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/scene-stage/package.json
+++ b/plugins/scene-stage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-scene-stage",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/story-guard/package.json
+++ b/plugins/story-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-story-guard",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/world-init/package.json
+++ b/plugins/world-init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@covel/plugin-world-init",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/world-init/runtimes/schema-gen/PLUGIN.md
+++ b/plugins/world-init/runtimes/schema-gen/PLUGIN.md
@@ -29,9 +29,6 @@ tools:
   plugin:
     - set-world-schema
     - set-world-entries-batch
-  builtin:
-    - plugin-data-get
-    - plugin-data-list
 ui:
   right:
     # world-entries.json removed: for imported worlds it was a raw-JSON dump of


### PR DESCRIPTION
## Release v0.0.20

4 commits. A follow-up to the v0.0.19 cleanup, driven by watching real sessions rather than by tests. Every fix here came from reading `trace_events` on a live playthrough — each one had been passing CI while misbehaving in production.

### Highlights

**A runtime could report success having done nothing** — `scene-prompts` answered a turn with prose, got the `requireToolUse` corrective nudge, and replied by calling only `runtime-done` with the reason "完成 scene prompts 生成". `generate-scene-prompts` was never called. The turn reported success in 47.6s and the player got an empty quick-reply panel behind a green check, with nothing in the trace to explain it.

Two paths let it through, and the second is the one production actually took:
- the gate counted any successful call, terminator included — even though the same file already filters `runtime-done` out of business output twenty lines earlier;
- the runtime-done early exit breaks the loop **before** the gate runs, so a terminator-only round never reached the check.

Both now require a business tool call, and an unmet contract finalizes as `failed` with a diagnostic. Releasing on a stubborn model is still the behaviour — it just stops lying about the outcome.

**A hazard warning that was always false** — any manifest declaring a `ui` block was credited with writing `ui:*`, so every pair of UI-declaring runtimes in a DAG layer was flagged. A three-turn session produced nine warnings, none real: a right-panel plugin cannot overwrite a message block. Effects now key on the declared slot. Verified on a fresh session: 3 warnings per turn → 1, and the survivor is the pair that genuinely shares a surface.

**Tools the prompts forbade** — five declarations were paid for twice, once in the tool schema on every LLM call and once in the prompt text spent forbidding them. Removed from `character-tracker`, both image `prompt-generator` runtimes, and `world-init/schema-gen`. `get-character` and `list-npc-graph` were kept: they are the documented escape hatch for a truncated snapshot, and a live session confirmed `get-character` being used exactly that way — first turn reads full attributes then updates, second turn updates directly, third turn does nothing.

### Verification

- `pnpm lint` — 21/21 packages
- `pnpm test` — 43/43 tasks
- PG contract suite — 186 passed against a real Postgres
- `pnpm release:preflight` — 6/6
- Diff audited for key patterns and local paths — clean
- Behaviour confirmed on a live session (`haruka-academy-37a78fc7`): 23 proposals committed, zero errors, hazard noise down to the one true pair, and `scene-prompts` recovering through the corrective retry as designed

### Release

Merging this PR and pushing the `v0.0.20` tag triggers `release.yml`, which builds the desktop artifacts and publishes the GitHub Release. The body is extracted from the `## [0.0.20]` section of `docs/CHANGELOG.md`.

---

_中文摘要：v0.0.19 清理版本的后续，全部来自观察真实对局的 trace，而非测试。三个修复：runtime 可能"什么都没做却报成功"（模型用框架的循环终止信号冒充完工，玩家看到绿勾配空面板）；UI 冲突警告每轮必报且全是假的（右栏插件与消息块被判为互相覆盖）；五个工具被下发给"提示词明令禁止调用它们"的 runtime。保留了 `get-character` 与 `list-npc-graph`——它们是摘要被截断时的逃生口，实测确认按设计被使用。_