### PR TITLE
ci: run the build step on main only, not on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,12 @@ jobs:
       - name: Test
         run: pnpm test
 
+      # Only the three apps have a build script, so this covers the bundling
+      # layer (vite/rolldown config, manualChunks, circular imports) that
+      # `tsc --noEmit` in Lint cannot see. Kept off PRs for faster feedback —
+      # push to main still gates it, well before a release tag would.
       - name: Build
+        if: github.event_name == 'push'
         run: pnpm build
 
       - name: Check plugin/world i18n coverage + READMEs


### PR DESCRIPTION
CI-only change, no release.

## What

`pnpm build` moves behind `if: github.event_name == 'push'`. Since the push trigger is scoped to `main`, that means: PRs run lint + test, main additionally runs build.

## Why keep it at all

Only three packages define a build script:

```
apps/web      tsc -b && vite build
apps/server   tsc -b
apps/desktop  node scripts/build.mjs
```

`packages/*` have none, so `test`'s `dependsOn: ["^build"]` is a no-op for them and this step is the *only* place the app bundling layer is exercised — vite/rolldown config, `manualChunks`, circular imports. `tsc --noEmit` in the Lint step cannot see any of it. The `perf(web)` commit in v0.0.21 is the case in point: a `manualChunks` rule pulled 194 kB of graph code into every chunk and silently defeated its `lazy()`. Only a real build surfaces that.

## Why move it off PRs

~2 minutes on every PR push. Catching a bundling regression when it lands on main is early enough — still well before a release tag would build it, and far cheaper than discovering it mid-release (delete tag, fix, re-tag).

## Checked

- `check:i18n` runs after this step and does not read build output — confirmed by running it against a tree with no `dist/`.
- `actionlint` and prettier pass.

---

_中文摘要：把 `pnpm build` 改成只在 push 到 main 时跑，PR 只跑 lint + test。保留它是因为只有三个 app 有 build 脚本，而这一步是唯一验证打包层（vite/rolldown 配置、manualChunks、循环依赖）的地方——lint 的 `tsc --noEmit` 看不到这些，v0.0.21 里那个 manualChunks 导致 lazy() 失效的问题就是例子。移出 PR 是因为每次推送多等两分钟不划算，而合并到 main 时拦住已经足够早，远早于打 tag 发布。_