### PR TITLE
fix(web): appearance review follow-ups — theme id collision + a11y

### DIFF
--- a/apps/web/src/components/appearance/TokenControl.tsx
+++ b/apps/web/src/components/appearance/TokenControl.tsx
@@ -131,7 +131,7 @@ interface TokenInputProps {
 function TokenInput({ spec, value, onPreview, onReset }: TokenInputProps) {
   switch (spec.control) {
     case "color":
-      return <ColorInput value={value} onPreview={onPreview} />;
+      return <ColorInput spec={spec} value={value} onPreview={onPreview} />;
     case "length":
       return <LengthInput spec={spec} value={value} onPreview={onPreview} />;
     case "number":
@@ -165,16 +165,23 @@ const FIELD_CLASS =
   "border border-[var(--rule-color)] bg-[var(--surface-page)] px-2 py-1 text-[11px] font-mono outline-none focus:ring-1 focus:ring-[var(--accent-primary)] rounded-[var(--radius-control)]";
 
 function ColorInput({
+  spec,
   value,
   onPreview,
 }: {
+  spec: TokenSpec;
   value: string;
   onPreview: (value: string) => void;
 }) {
+  const { i18n } = useTranslation();
   const [text, setText] = useState(value);
   useEffect(() => setText(value), [value]);
   const swatch = toSwatchHex(value) ?? "#000000";
   const valid = !text.trim() || isValidCssColor(text);
+  // Both fields carry the token's own name: a shared literal meant a screen
+  // reader announced the same word for all 48 swatches, with no way to tell
+  // the page background from the danger accent.
+  const label = resolveI18nText(spec.label, i18n.language) ?? spec.name;
 
   return (
     <div className="flex items-center gap-1.5">
@@ -182,12 +189,13 @@ function ColorInput({
         type="color"
         value={swatch}
         onChange={(event) => onPreview(event.target.value)}
-        aria-label="colour"
+        aria-label={label}
         className="h-6 w-8 cursor-pointer border border-[var(--rule-color)] bg-transparent p-0.5 rounded-[var(--radius-control)]"
       />
       <input
         type="text"
         value={text}
+        aria-label={label}
         spellCheck={false}
         onChange={(event) => {
           setText(event.target.value);

--- a/apps/web/src/settings/panes/AppearancePane.tsx
+++ b/apps/web/src/settings/panes/AppearancePane.tsx
@@ -204,6 +204,9 @@ export function AppearancePane() {
           <input
             type="text"
             value={themeName}
+            // A placeholder is not a reliable accessible name and disappears
+            // as soon as the player types.
+            aria-label={t("appearance.saveAsThemeTitle")}
             placeholder={t("appearance.themeNamePlaceholder")}
             onChange={(event) => setThemeName(event.target.value)}
             onKeyDown={(event) => {

--- a/apps/web/src/theme-system/__tests__/theme-export.test.ts
+++ b/apps/web/src/theme-system/__tests__/theme-export.test.ts
@@ -51,10 +51,22 @@ describe("theme id derivation", () => {
     expect(slugifyThemeId("  Neon__Drift!! ")).toBe("neon-drift");
   });
 
-  it("falls back for names that slugify to nothing", () => {
+  it("gives names that slugify to nothing a name-derived id", () => {
     // CJK names are common here and carry no latin characters at all.
-    expect(slugifyThemeId("我的主题")).toBe("custom-theme");
-    expect(slugifyThemeId("!!!")).toBe("custom-theme");
+    const id = slugifyThemeId("我的主题");
+    expect(id).toMatch(/^custom-theme-[a-z0-9]+$/);
+    // Stable: re-saving the same name must update that theme, not add another.
+    expect(slugifyThemeId("我的主题")).toBe(id);
+    expect(slugifyThemeId("  我的主题  ")).toBe(id);
+  });
+
+  it("never gives two different non-latin names the same id", () => {
+    // Regression: a shared constant fallback made every Chinese-named theme
+    // collide, and saveCustomTheme de-duplicates by id — so saving a second
+    // one silently deleted the first.
+    const names = ["我的极光", "我的纸本", "夜读模式", "深色护眼", "ダーク"];
+    const ids = names.map(slugifyThemeId);
+    expect(new Set(ids).size).toBe(names.length);
   });
 
   it("never lands on a builtin id", () => {

--- a/apps/web/src/theme-system/overrides.ts
+++ b/apps/web/src/theme-system/overrides.ts
@@ -131,9 +131,13 @@ export function applyTokenOverrides(store: SettingsStoreApi): void {
 export function readTokenDefaults(): Record<string, string> {
   if (typeof document === "undefined") return {};
   const root = document.documentElement;
-  const lifted = appliedProperties.map(
-    (name) => [name, root.style.getPropertyValue(name)] as const,
-  );
+  // Lift every adjustable token, not just the ones this module wrote: the
+  // controls paint directly to the element during a drag preview, and inside
+  // that debounce window those two views of the DOM disagree — reading it back
+  // would report a half-dragged preview as the theme's own default.
+  const lifted = listAdjustableTokens()
+    .map((name) => [name, root.style.getPropertyValue(name)] as const)
+    .filter(([, value]) => value !== "");
 
   for (const [name] of lifted) root.style.removeProperty(name);
   const computed = getComputedStyle(root);

--- a/apps/web/src/theme-system/theme-export.ts
+++ b/apps/web/src/theme-system/theme-export.ts
@@ -232,18 +232,34 @@ export function buildThemeCss(
   };
 }
 
-/** `我的主题 2` → `my-theme-2`-ish; falls back to a stable generic id. */
+/**
+ * Fallback id for names that carry no latin characters at all.
+ *
+ * A shared constant here was a data-loss bug: every Chinese-named theme got
+ * the same id, and `saveCustomTheme` de-duplicates by id, so saving a second
+ * one silently deleted the first. Deriving the suffix from the name keeps
+ * re-saving the *same* name an update (same id, as intended) while two
+ * different names no longer collide.
+ */
+function fallbackThemeId(name: string): string {
+  let hash = 0;
+  for (let index = 0; index < name.length; index++) {
+    hash = (Math.imul(hash, 31) + name.charCodeAt(index)) | 0;
+  }
+  return `custom-theme-${(hash >>> 0).toString(36)}`;
+}
+
+/** `我的主题 2` → `my-theme-2`-ish; non-latin names get a name-derived id. */
 export function slugifyThemeId(input: string): string {
-  const slug = input
-    .trim()
+  const trimmed = input.trim();
+  const slug = trimmed
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 48);
-  // Non-latin names (Chinese, Japanese) slugify to nothing — the id is an
-  // internal selector token, so a generic one is fine; the label keeps the
-  // player's original text.
-  return slug.length >= 2 ? slug : "custom-theme";
+  // The id is an internal selector token; the label keeps the player's
+  // original text either way.
+  return slug.length >= 2 ? slug : fallbackThemeId(trimmed);
 }
 
 /**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. Follows [Ke
 
 ## [Unreleased]
 
+### Fixed
+
+- **Saving a theme with a Chinese name no longer deletes the previous one.** `slugifyThemeId` strips every non-`[a-z0-9]` character, so an all-CJK name reduced to an empty string and fell back to the shared constant `custom-theme` — 我的极光, 我的纸本 and 夜读模式 all produced the same id. `ensureThemeId` only de-duplicated against builtin ids, and `saveCustomTheme` writes with `filter(id !== …).concat(…)`, so the second save silently dropped the first theme with no warning and no undo. In a Chinese-first product that is the main path, not an edge case. The fallback is now derived from the name itself, which keeps re-saving the same name an update (same id, as intended) while two different names no longer collide.
+- **Colour swatches announce which token they belong to.** All 48 shared one hardcoded `aria-label="colour"`, so a screen-reader user heard the same word 48 times with no way to tell the page background from the danger accent. Both the swatch and its paired text field now carry the token's own label. The theme-name field gained an accessible name too — it had only a placeholder, which is not a reliable one and vanishes on input.
+- **Reading theme defaults ignores an in-flight drag preview.** `readTokenDefaults` lifted only the properties the override module had written, but the controls also paint directly to the element while a slider is being dragged. Inside the 200 ms commit debounce those two views disagreed, so a theme or scheme switch landing in that window could record a half-dragged preview as the theme's own default. It now lifts every adjustable token regardless of who wrote it.
+
 ## [0.0.22] - 2026-07-26
 
 Appearance stops being a three-way switch. The token system was already complete — every theme defines it and every atom consumes it — so what was missing was never the plumbing, only a way for the player to reach it. This release exposes 45 of those tokens grouped by the region they affect, adds a path from "I tuned it" to "here is a theme package", and publishes turn state to the DOM so a theme can finally react to what the game is doing. The rest is player-facing correctness: two inputs that accepted what they shouldn't, and one that rendered less than it should.


### PR DESCRIPTION
Follow-up to the post-merge review of #32. No version bump — these ride along with the next release.

## HIGH — a Chinese theme name deleted the previous theme

`slugifyThemeId` strips every non-`[a-z0-9]` character, so an all-CJK name reduced to an empty string and fell back to the shared constant `custom-theme`:

| Player input | Before | After |
| --- | --- | --- |
| 我的极光 | `custom-theme` | `custom-theme-cv5517` |
| 我的纸本 | `custom-theme` | `custom-theme-cv97if` |
| 夜读模式 | `custom-theme` | `custom-theme-btmpil` |

`ensureThemeId` only de-duplicated against builtin ids, and `saveCustomTheme` writes with `filter(id !== …).concat(…)` — so the second save silently dropped the first theme, no warning and no undo. In a Chinese-first product this is the main path, not an edge case.

The fix derives the fallback from the name itself instead of using a constant. Re-saving the *same* name still resolves to the same id (that case is meant to be an update), while two different names no longer collide. Two regression tests pin both halves.

## MEDIUM — accessibility

- All 48 colour swatches shared one hardcoded `aria-label="colour"`. A screen-reader user heard the same word 48 times with no way to tell the page background from the danger accent. Both the swatch and its paired text field now carry the token's own label.
- The theme-name field had only a `placeholder`, which is not a reliable accessible name and disappears once typing starts.

## LOW — preview leaking into "theme default"

`readTokenDefaults` lifted only the properties the override module had written, but the controls paint directly to the element mid-drag. Inside the 200 ms commit debounce those two views of the DOM disagree, so a theme/scheme switch landing in that window could record a half-dragged preview as the theme's own default. It now lifts every adjustable token regardless of which path wrote it.

## Deliberately not changed

**aurora's full-viewport blur animation.** Browsers already throttle CSS animations in hidden tabs, the foreground compositing cost is that theme's deliberate trade-off (showing what the theme layer can do is its whole purpose), and `prefers-reduced-motion` already covers the accessibility need. Changing it to clear a review checklist would be a fake fix.

**The "45 tokens" figure** in the published `## [0.0.22]` CHANGELOG section (actual count: 48). That section is the source the published GitHub Release body was extracted from, so correcting one without the other creates a worse mismatch. Left for a deliberate call rather than silently editing shipped history.

## Verification

- `pnpm lint` — 21/21
- `pnpm test` — 43/43, 490 web tests (+1)
- `pnpm check:i18n` — OK
- Collision check re-run over 5 representative names: 5 unique ids, and the same name is idempotent

---

_修复上一版 review 发现的问题：中文主题名会静默删掉先前保存的主题（所有纯中文名都落到同一个 id）；48 个色板对屏幕阅读器只报同一个词；主题名输入框缺可访问名；拖拽预览值可能被误记为主题默认值。aurora 的动画开销与已发布 CHANGELOG 里的数字偏差都未改动，理由见上。_
