### PR TITLE
fix: let a select option explain itself without entering the prose

### DIFF
--- a/packages/tools/src/builtin/ui-tools.ts
+++ b/packages/tools/src/builtin/ui-tools.ts
@@ -58,12 +58,35 @@ export const renderUITool = tool({
 
 // ── create-form ──────────────────────────────────────────────────
 
+/**
+ * A select option. The bare string form uses one text for both jobs; the
+ * object form separates them, which matters because the submitted value is
+ * what `narrativeTemplate` interpolates.
+ *
+ * An option written to help the player choose ("旧地重游 —— 与青砾町有过一段旧事")
+ * reads as a dash-inside-a-dash when spliced into a sentence. Giving the
+ * option a short `value` and a descriptive `label` keeps the picker helpful
+ * without dragging its explanation into the prose.
+ */
+const formFieldOptionSchema = z.union([
+  z.string(),
+  z.object({
+    value: z.string().min(1).describe("提交值，也是叙事模板里插入的文本"),
+    label: z.string().min(1).describe("下拉里展示给玩家的完整描述"),
+  }),
+]);
+
 const formFieldSchema = z.object({
   type: z.enum(["text", "textarea", "select", "checkbox", "number"]),
   name: z.string().min(1),
   label: z.string().min(1),
   placeholder: z.string().optional(),
-  options: z.array(z.string()).optional(),
+  options: z
+    .array(formFieldOptionSchema)
+    .optional()
+    .describe(
+      "select 选项。字符串形式下展示文本即提交值；需要「展示详细、叙事简洁」时用 { value, label }",
+    ),
   required: z.boolean().optional(),
   defaultValue: z.string().optional(),
 });
@@ -85,7 +108,10 @@ export const createFormTool = tool({
     narrativeTemplate: z
       .string()
       .describe(
-        "叙事模板，包含 {{fieldName}} 占位符，玩家提交后由框架填充为完整叙事",
+        "叙事模板，包含 {{fieldName}} 占位符，玩家提交后由框架填入该字段的提交值。" +
+          "select 字段填入的是选项的 value（字符串选项即其本身），因此选项若写成" +
+          "「短标签 —— 长解释」，整串都会进正文；这种情况改用 { value, label }，" +
+          "把短标签放 value、解释放 label",
       ),
     submitBehavior: submitBehaviorSchema
       .optional()

--- a/packages/tools/tests/ui-tools.test.ts
+++ b/packages/tools/tests/ui-tools.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { normalizeUIRenderInstruction } from "@covel/shared";
-import { createNotificationTool, renderUITool } from "../src/index.js";
+import {
+  createFormTool,
+  createNotificationTool,
+  renderUITool,
+} from "../src/index.js";
 
 const CTX = {
   sessionId: "sess-1",
@@ -88,5 +92,66 @@ describe("builtin ui tools", () => {
         message: "水源已污染。",
       },
     });
+  });
+});
+
+describe("create-form select options", () => {
+  // The submitted value is what `narrativeTemplate` interpolates. An option
+  // written to help the player choose ("旧地重游 —— 与青砾町有过一段旧事") is
+  // exactly the wrong thing to splice into a sentence, so the object form has
+  // to survive the schema intact for a plugin to separate the two.
+  it("accepts { value, label } options and preserves both", async () => {
+    const result = (await createFormTool.execute(
+      {
+        formId: "char-creation",
+        title: "转学生档案",
+        submitLabel: "踏入教室",
+        narrativeTemplate: "你的转学原因——{{transferReason}}——已经写进故事。",
+        fields: [
+          {
+            type: "select",
+            name: "transferReason",
+            label: "转学原因",
+            options: [
+              {
+                value: "旧地重游",
+                label: "旧地重游 —— 与青砾町有过一段旧事，想要回来",
+              },
+            ],
+          },
+        ],
+      },
+      CTX,
+    )) as {
+      interaction: {
+        fields: Array<{ options?: Array<{ value: string; label: string }> }>;
+      };
+    };
+
+    const opt = result.interaction.fields[0]!.options![0]!;
+    expect(opt.value).toBe("旧地重游");
+    expect(opt.label).toContain("与青砾町有过一段旧事");
+  });
+
+  it("still accepts plain string options", async () => {
+    const result = (await createFormTool.execute(
+      {
+        formId: "f",
+        title: "t",
+        submitLabel: "ok",
+        narrativeTemplate: "{{club}}",
+        fields: [
+          {
+            type: "select",
+            name: "club",
+            label: "社团",
+            options: ["文艺部", "轻音部"],
+          },
+        ],
+      },
+      CTX,
+    )) as { interaction: { fields: Array<{ options?: unknown[] }> } };
+
+    expect(result.interaction.fields[0]!.options).toEqual(["文艺部", "轻音部"]);
   });
 });

--- a/plugins/char-creator/runtimes/player-init/PLUGIN.en.md
+++ b/plugins/char-creator/runtimes/player-init/PLUGIN.en.md
@@ -48,6 +48,8 @@ The opening summary is provided in the `<pregame-opening>` block at the end of t
 5. Type mapping: `enum` → `select`; `string` → `text`; `number` → generate 3–5 `select` options from a reasonable range; `array` → `text` (comma-separated placeholder)
 6. Apart from `characterName`, every field is `required: false`
 7. **Numeric stats do not enter the form** — the guard auto-fills them from the schema's `defaultValue` when the player submits.
+8. **When a select option needs an explanation, use the two-part `{ value, label }` form**: `value` is a short phrase that reads naturally inside a sentence ("returning home"), `label` is the full description that helps the player choose ("Returning home — you have history in Aoiseki, and you came back for it").
+   The narrative template interpolates the `value`, so an option written as one long string yields prose like "your reason for transferring — returning home — you have history in Aoiseki, and you came back for it — is now part of your story", a dash inside a dash. When the option is already short ("Literature Club"), a plain string is fine.
 
 ### `create-form` parameters
 

--- a/plugins/char-creator/runtimes/player-init/PLUGIN.md
+++ b/plugins/char-creator/runtimes/player-init/PLUGIN.md
@@ -94,6 +94,8 @@ postHistory:
 5. 类型映射：`enum` → `select`；`string` → `text`；`number` → 从合理范围生成 3-5 个 select 选项；`array` → `text`（placeholder 逗号分隔）
 6. 除 `characterName` 外，所有字段 `required: false`
 7. **数值型 stats** 不进表单（由 guard 用 schema `defaultValue` 自动填入）
+8. **select 选项要给玩家解释，就用 `{ value, label }` 两段式**：`value` 是能直接嵌进句子的短词（"旧地重游"），`label` 是下拉里帮助玩家判断的完整描述（"旧地重游 —— 与青砾町有过一段旧事，想要回来"）。
+   叙事模板填入的是 `value`，写成一整串的选项会让正文出现「你的转学原因——旧地重游——与青砾町有过一段旧事，想要回来——已经写进了故事」这种破折号套破折号。选项本身就足够短时（"文艺部"）直接用字符串即可。
 
 ### 调用 create-form 参数
 


### PR DESCRIPTION
## Let a select option explain itself without entering the prose

Found by actually playing a session in a browser after v0.0.23 shipped — it is the very first thing a new player reads.

The character-creation form opened with:

> 你的转学原因——旧地重游——与青砾町有过一段旧事，想要回来——已经写进了自己的故事里

A dash inside a dash, reading like a form echo rather than narration.

### Cause

One string is doing two jobs. `narrativeTemplate` interpolates the *submitted value*, and for a `select` that value is the option text. So an option written to help the player choose —

```
旧地重游 —— 与青砾町有过一段旧事，想要回来
```

— drags its own explanation into the sentence. Shortening the options would fix the prose and make the picker worse. The two needs are genuinely different, and one string cannot serve both.

### Fix

The renderer had already solved this and was waiting on the schema:

- `lib/message-to-spec.ts` normalises `string | { value, label }`
- `FormField` renders `<option value={opt.value}>{opt.label}</option>` — displays the label, submits the value

Only `create-form`'s zod schema still forced the bare-string form. This widens it to accept the object form and documents, on both `options` and `narrativeTemplate`, which of the two ends up in the prose. The char-creator prompt that produced the sentence above now says when to reach for the two-part form, in both locale variants.

Plain string options keep working unchanged — a test pins that.

### Deliberately not done

The framework does not shorten long option text at interpolation time. Guessing where an author's label ends and their explanation begins is not something the kernel can do correctly, and the dash convention it would key off is language-specific.

### Verification

- `@covel/tools` 105 (2 new: object form preserved, string form still accepted)
- `@covel/runtime` 843 · `@covel/server` 711 · `@covel/web` 495 · `char-creator` 19
- `pnpm lint` 21/21 · `pnpm validate:plugin plugins/char-creator` clean · `pnpm check:i18n` clean

Not re-verified in a live session: the fix changes what the model is *told* to generate, so confirming the prose actually improves needs another real playthrough. The mechanical contract (schema accepts both shapes, renderer splits them correctly) is covered by tests.

---

_中文摘要：v0.0.23 发布后用浏览器实际玩了一局，开局第一段文字就露出问题——选项的完整文本被插进叙事，成了破折号套破折号，读起来像表单回显。根因是同一个字符串既要在下拉里帮玩家判断、又要作为提交值进正文，这两件事天然冲突。前端其实早就支持 `{value,label}` 分离（显示 label、提交 value），只有工具 schema 还卡着纯字符串——放开它，并在两处说明哪个值会进正文，char-creator 提示词补上何时使用。纯字符串选项保持兼容。框架不去猜测截断长选项：那依赖语言相关的破折号约定，内核做不对。_
