### PR TITLE
fix(web): stop entering a world from depending on a painted frame

### DIFF
--- a/apps/web/src/components/session/__tests__/world-select-enter.test.tsx
+++ b/apps/web/src/components/session/__tests__/world-select-enter.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Entering a world must not depend on a frame being painted.
+ *
+ * The navigation used to be deferred to `requestAnimationFrame` so the busy
+ * state could paint first. Browsers pause rAF while a page is hidden, so a
+ * click on a backgrounded or throttled tab set the busy flag and then never
+ * navigated — the card spun forever, every other card became
+ * `pointer-events-none`, and nothing short of a reload recovered it.
+ *
+ * These tests stub rAF into a no-op to stand in for a hidden page: the first
+ * one fails against the deferred implementation, the second pins the escape
+ * hatch that keeps a failed navigation from stranding the grid.
+ */
+
+import { fireEvent, render, screen, act } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WorldSelectScreen } from "../world-select-screen.js";
+import type { WorldRecord } from "@/services/api.js";
+
+const WORLDS = [
+  {
+    id: "haruka-academy",
+    name: "遥风学园",
+    description: "一所海边私立高中",
+  } as WorldRecord,
+];
+
+function renderScreen(onSelectWorld: (id: string) => void) {
+  return render(
+    <WorldSelectScreen
+      worlds={WORLDS}
+      packages={[]}
+      resolvedSlots={[]}
+      settingsOpen={false}
+      onSettingsOpenChange={() => {}}
+      onSelectWorld={onSelectWorld}
+    />,
+  );
+}
+
+/** Stand in for a hidden page: rAF callbacks are registered and never run. */
+function suspendAnimationFrames() {
+  vi.stubGlobal("requestAnimationFrame", () => 0);
+  vi.stubGlobal("cancelAnimationFrame", () => {});
+}
+
+describe("world select — entering a world", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("navigates even when animation frames never fire", () => {
+    suspendAnimationFrames();
+    const onSelectWorld = vi.fn();
+    renderScreen(onSelectWorld);
+
+    fireEvent.click(screen.getByText("遥风学园"));
+
+    expect(onSelectWorld).toHaveBeenCalledWith("haruka-academy");
+  });
+
+  it("releases the busy lock when the navigation does not take", () => {
+    vi.useFakeTimers();
+    suspendAnimationFrames();
+    // A selection that goes nowhere — the screen stays mounted, which is the
+    // exact state that used to be unrecoverable.
+    const { container } = renderScreen(() => {});
+
+    fireEvent.click(screen.getByText("遥风学园"));
+    expect(container.querySelector('article[aria-busy="true"]')).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(container.querySelector('article[aria-busy="true"]')).toBeNull();
+  });
+});

--- a/apps/web/src/components/session/world-select-screen.tsx
+++ b/apps/web/src/components/session/world-select-screen.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button.js";
 import {
@@ -86,13 +86,27 @@ export function WorldSelectScreen({
   const [deletingWorldId, setDeletingWorldId] = useState<string | null>(null);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
 
+  // Entering a world used to defer the actual navigation to
+  // `requestAnimationFrame`, so the busy state could paint one frame first.
+  // Browsers pause rAF while a page is hidden, so a click on a backgrounded
+  // or throttled tab set the busy flag and then never navigated: the card
+  // spun forever, every other card went `pointer-events-none`, and there was
+  // no error and no way back short of a reload. Selecting a world is two
+  // dispatches — nothing worth deferring behind a frame that may never come.
   function handleEnterWorld(worldId: string) {
     if (enteringWorldId) return;
     setEnteringWorldId(worldId);
-    window.requestAnimationFrame(() => {
-      onSelectWorld(worldId);
-    });
+    onSelectWorld(worldId);
   }
+
+  // A successful selection unmounts this screen, so the flag disappears with
+  // it. Still being mounted means the navigation did not take — release the
+  // lock instead of stranding the player on a dead grid.
+  useEffect(() => {
+    if (!enteringWorldId) return;
+    const timer = setTimeout(() => setEnteringWorldId(null), 1500);
+    return () => clearTimeout(timer);
+  }, [enteringWorldId]);
 
   const selectedWorld = selectedWorldId
     ? (worlds.find((w) => w.id === selectedWorldId) ?? null)


### PR DESCRIPTION
## Stop entering a world from depending on a painted frame

Found while driving the app in a browser to verify #36 — the world grid would not respond to clicks at all.

### Cause

`handleEnterWorld` did two things, one synchronous and one not:

```js
setEnteringWorldId(worldId);                                // spinner goes up
window.requestAnimationFrame(() => onSelectWorld(worldId));  // navigation
```

The rAF only existed so the busy state could paint one frame before the screen swapped. But **browsers pause rAF while a page is hidden**, so on a backgrounded or throttled tab the flag went up and the callback never ran:

- the clicked card spins forever
- every other card becomes `pointer-events-none` (`dimmed`)
- no request is sent, no error is surfaced
- `enteringWorldId` has no reset path — a page reload is the only way out

Confirmed directly: `document.visibilityState === "hidden"` and a probe rAF that never fires within 3s.

### Fix

Call `onSelectWorld` directly. Selecting a world is two dispatches — there is nothing worth deferring behind a frame that may never arrive.

Also release the lock if the screen is still mounted 1.5s later. A successful selection unmounts this screen, so surviving that long means the navigation did not take; letting the player retry beats leaving them on a dead grid.

### Why `sse-handler`'s rAF is left alone

It has the same shape but not the same risk: it is a pure render throttle, and `flushNarrativeDeltaBuffer` is also called synchronously when a story stream completes. A hidden page delays painting there without losing content. This one had no such fallback — that asymmetry is the actual bug.

### Honest scope

For a real player this is mostly latent: you are looking at the screen when you click, so the page is visible. It bites on a backgrounded tab, under browser throttling, or in any automated/headless driver. The severity is less "players cannot start games" and more "a UI state machine with no way out of its own busy flag".

### Verification

- New test stubs rAF into a no-op to stand in for a hidden page. **Red-light checked**: it fails against the deferred implementation.
- Reproduced and re-verified end to end in a real hidden-tab browser session — before the fix the click never left the world list, after it the prep screen opens.
- `@covel/web` 497 · `pnpm lint` 21/21

---

_中文摘要：为 #36 做浏览器验证时发现世界卡片点了没反应。原因是「进入世界」把导航推迟到 `requestAnimationFrame`，只为让转圈状态先画一帧；而浏览器在页面隐藏时会暂停 rAF，于是 busy 挂上、导航永不发生，其余卡片还被置为不可点击，且这个状态没有任何复位路径，只能刷新页面。改为直接调用（本来只是两个 dispatch），并在 1.5 秒后释放锁，让玩家能重试。同库的 `sse-handler` 也用 rAF 但保留不动——它是纯渲染节流且有非 rAF 的兜底 flush，这种不对称正是本 bug 的实质。对真实玩家影响有限（点击时页面通常可见），主要发生在后台标签页、浏览器节流或自动化环境。_
