### PR TITLE
fix(desktop): exclude top-level _ dirs from sidecar staging

### DIFF
--- a/apps/desktop/scripts/build.mjs
+++ b/apps/desktop/scripts/build.mjs
@@ -331,7 +331,14 @@ for (const entry of sideCarResources) {
   }
   fs.cpSync(src, dest, {
     recursive: true,
-    filter: (source) => !EXCLUDE_DIRS.has(path.basename(source)),
+    filter: (source) => {
+      const base = path.basename(source);
+      if (EXCLUDE_DIRS.has(base)) return false;
+      // Top-level `_` dirs are non-content conventions (plugins/_archive,
+      // worlds/_archive): never loaded at runtime, dead weight in the app.
+      if (base.startsWith("_") && path.dirname(source) === src) return false;
+      return true;
+    },
   });
 }
 console.log("  ✓ plugins/prompts/worlds copied (node_modules/dist excluded)");

--- a/apps/desktop/scripts/verify-release.mjs
+++ b/apps/desktop/scripts/verify-release.mjs
@@ -68,7 +68,9 @@ function mustHaveBundledPlugins(resourcesDir) {
   }
   const pluginDirs = fs
     .readdirSync(pluginsDir, { withFileTypes: true })
-    .filter((e) => e.isDirectory());
+    // `_`-prefixed dirs (plugins/_archive) are excluded from staging; tolerate
+    // one slipping through an older build rather than failing the release.
+    .filter((e) => e.isDirectory() && !e.name.startsWith("_"));
   if (pluginDirs.length === 0) {
     throw new Error(`No bundled plugins present under ${pluginsDir} `);
   }


### PR DESCRIPTION
The v0.0.24 tag build failed at 'Verify unpacked release resources': the wholesale `plugins/` copy staged `plugins/_archive` into the app and the verifier failed it as a bundled plugin with no `package.json`.

- `build.mjs` staging filter now skips `_`-prefixed dirs at the resource root (also stops shipping `worlds/_archive` as dead weight)
- `verify-release.mjs` tolerates an archived dir slipping through an older build

Third member of the `_archive` family (after the release-preflight scan and the workspace glob). Local `pnpm build:electron` + `node apps/desktop/scripts/verify-release.mjs mac` re-run to confirm before merge; v0.0.24 will be re-tagged on the merge commit.