### PR TITLE
feat(web): World Import Review / Edit UI (v0 fixture, mock intake)

### DIFF
--- a/apps/web/src/features/world-import-review/__tests__/draft-actions.test.ts
+++ b/apps/web/src/features/world-import-review/__tests__/draft-actions.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import fixtureDraftJson from "../fixture/world-import-draft-v0.json";
+import {
+  acceptAiInference,
+  countByProvenance,
+  countByType,
+  deleteEntry,
+  filterEntriesByType,
+  findEntry,
+  resolveSourceTitle,
+  setConflictResolved,
+  updateEntry,
+} from "../draft-actions.js";
+import { buildExportPayload } from "../draft-service.js";
+import { parseWorldImportDraft } from "../types.js";
+
+function fixture() {
+  const parsed = parseWorldImportDraft(fixtureDraftJson);
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed.draft;
+}
+
+describe("draft-actions", () => {
+  it("updateEntry stamps userEdited and patches only the target entry", () => {
+    const draft = fixture();
+    const next = updateEntry(draft, "char-lu-mingfei", {
+      name: "路明非(审)",
+      aliases: ["路少爷", "LU"],
+    });
+    const edited = findEntry(next, "char-lu-mingfei");
+    expect(edited?.userEdited).toBe(true);
+    expect(edited?.name).toBe("路明非(审)");
+    expect(edited?.aliases).toEqual(["路少爷", "LU"]);
+    // Untouched entries stay pristine.
+    expect(findEntry(next, "char-nono")?.userEdited).toBe(false);
+  });
+
+  it("acceptAiInference only affects ai-inferred entries", () => {
+    const draft = fixture();
+    const accepted = acceptAiInference(draft, "faction-dragon-research");
+    expect(findEntry(accepted, "faction-dragon-research")?.aiAccepted).toBe(
+      true,
+    );
+    // A source-backed entry must not gain the flag.
+    const refused = acceptAiInference(draft, "char-lu-mingfei");
+    expect(findEntry(refused, "char-lu-mingfei")?.aiAccepted).toBeUndefined();
+  });
+
+  it("deleteEntry removes exactly one entry", () => {
+    const draft = fixture();
+    const next = deleteEntry(draft, "relation-lu-nono");
+    expect(findEntry(next, "relation-lu-nono")).toBeNull();
+    expect(next.entries.length).toBe(draft.entries.length - 1);
+  });
+
+  it("setConflictResolved only affects conflict entries", () => {
+    const draft = fixture();
+    const next = setConflictResolved(draft, "rule-blood-suppression", true);
+    expect(findEntry(next, "rule-blood-suppression")?.conflictResolved).toBe(
+      true,
+    );
+    const ignored = setConflictResolved(draft, "char-lu-mingfei", true);
+    expect(
+      findEntry(ignored, "char-lu-mingfei")?.conflictResolved,
+    ).toBeUndefined();
+  });
+
+  it("counts entries by type and provenance", () => {
+    const draft = fixture();
+    const byType = countByType(draft);
+    expect(byType.character).toBe(2);
+    expect(byType.rule).toBe(1);
+    const byProvenance = countByProvenance(draft);
+    expect(byProvenance.total).toBe(9);
+    expect(byProvenance.sourceBacked).toBe(6);
+    expect(byProvenance.aiInferred).toBe(2);
+    expect(byProvenance.conflict).toBe(1);
+    expect(byProvenance.unresolvedConflicts).toBe(1);
+    const resolved = setConflictResolved(draft, "rule-blood-suppression", true);
+    expect(countByProvenance(resolved).unresolvedConflicts).toBe(0);
+  });
+
+  it("filters entries by type", () => {
+    const draft = fixture();
+    expect(filterEntriesByType(draft, "character").map((e) => e.id)).toEqual([
+      "char-lu-mingfei",
+      "char-nono",
+    ]);
+    expect(filterEntriesByType(draft, null).length).toBe(9);
+  });
+
+  it("resolves source titles with a fallback to the raw id", () => {
+    const draft = fixture();
+    expect(resolveSourceTitle(draft, "src-longzu-book1-txt")).toContain(
+      "龙族 I",
+    );
+    expect(resolveSourceTitle(draft, "missing")).toBe("missing");
+  });
+
+  it("export payload keeps every owner decision", () => {
+    let draft = fixture();
+    draft = updateEntry(draft, "char-lu-mingfei", { name: "路明非(审)" });
+    draft = acceptAiInference(draft, "faction-dragon-research");
+    draft = setConflictResolved(draft, "rule-blood-suppression", true);
+    draft = deleteEntry(draft, "relation-lu-nono");
+    const payload = JSON.parse(buildExportPayload(draft));
+    const byId = new Map(payload.entries.map((e: { id: string }) => [e.id, e]));
+    expect(byId.get("char-lu-mingfei")).toMatchObject({
+      name: "路明非(审)",
+      userEdited: true,
+    });
+    expect(byId.get("faction-dragon-research")).toMatchObject({
+      aiAccepted: true,
+    });
+    expect(byId.get("rule-blood-suppression")).toMatchObject({
+      conflictResolved: true,
+    });
+    expect(byId.has("relation-lu-nono")).toBe(false);
+    expect(payload.version).toBe("v0");
+  });
+});

--- a/apps/web/src/features/world-import-review/__tests__/draft-store.test.ts
+++ b/apps/web/src/features/world-import-review/__tests__/draft-store.test.ts
@@ -1,0 +1,81 @@
+import "fake-indexeddb/auto";
+
+import { describe, expect, it } from "vitest";
+import fixtureDraftJson from "../fixture/world-import-draft-v0.json";
+import { WorldImportDraftStore } from "../draft-store.js";
+import { parseWorldImportDraft, type WorldImportDraft } from "../types.js";
+
+function fixture(): WorldImportDraft {
+  const parsed = parseWorldImportDraft(fixtureDraftJson);
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed.draft;
+}
+
+let dbCounter = 0;
+function newStore() {
+  dbCounter += 1;
+  return new WorldImportDraftStore(`test-world-import-review-${dbCounter}`);
+}
+
+describe("WorldImportDraftStore", () => {
+  it("returns null when no draft was saved", async () => {
+    const store = newStore();
+    expect(await store.load("world-import-fixture-longzu-v0")).toBeNull();
+  });
+
+  it("saves and reloads a draft unchanged", async () => {
+    const store = newStore();
+    const draft = fixture();
+    const savedAt = await store.save(draft);
+    expect(typeof savedAt).toBe("string");
+
+    const reloaded = await store.load(draft.id);
+    expect(reloaded).not.toBeNull();
+    expect(reloaded?.savedAt).toBe(savedAt);
+    expect(reloaded?.draft).toEqual(draft);
+  });
+
+  it("overwrites a previous save for the same draft id", async () => {
+    const store = newStore();
+    const draft = fixture();
+    await store.save(draft);
+    const edited = {
+      ...draft,
+      entries: draft.entries.map((e) =>
+        e.id === "char-lu-mingfei" ? { ...e, userEdited: true } : e,
+      ),
+    };
+    await store.save(edited);
+    const reloaded = await store.load(draft.id);
+    expect(
+      reloaded?.draft.entries.find((e) => e.id === "char-lu-mingfei")
+        ?.userEdited,
+    ).toBe(true);
+  });
+
+  it("clear removes the saved draft", async () => {
+    const store = newStore();
+    const draft = fixture();
+    await store.save(draft);
+    await store.clear(draft.id);
+    expect(await store.load(draft.id)).toBeNull();
+  });
+
+  it("rejects a corrupted saved record instead of returning it", async () => {
+    const store = newStore();
+    const draft = fixture();
+    await store.save(draft);
+    // Corrupt the record behind Dexie's back.
+    const db = await (
+      store as unknown as {
+        db: { table: (n: string) => { put: (r: unknown) => Promise<void> } };
+      }
+    ).db.table("drafts");
+    await db.put({
+      draftId: draft.id,
+      savedAt: new Date().toISOString(),
+      draft: { ...draft, entries: "not-an-array" },
+    });
+    await expect(store.load(draft.id)).rejects.toThrow(/failed validation/);
+  });
+});

--- a/apps/web/src/features/world-import-review/__tests__/review-flow.test.tsx
+++ b/apps/web/src/features/world-import-review/__tests__/review-flow.test.tsx
@@ -1,0 +1,202 @@
+import "fake-indexeddb/auto";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { ReviewPage } from "../components/review-page.js";
+import { WorldImportDraftStore } from "../draft-store.js";
+
+/**
+ * End-to-end review journey over the frozen v0 fixture, at the component
+ * level: load → browse categories → inspect sources → edit → decide on AI
+ * inferences → resolve conflict → save → reopen → export-ready state.
+ */
+
+const FIXTURE_TITLE = "龙族 I · 火之晨曦 — 世界导入草稿(审阅用 Fixture)";
+
+let dbCounter = 0;
+function newStore() {
+  dbCounter += 1;
+  return new WorldImportDraftStore(`test-review-flow-${dbCounter}`);
+}
+
+beforeEach(() => {
+  // No ConfirmHost is mounted in tests, so requestConfirm falls back to
+  // window.confirm; tests stub it per case.
+  vi.restoreAllMocks();
+});
+
+afterEach(cleanup);
+
+async function renderReview(store: WorldImportDraftStore) {
+  render(<ReviewPage store={store} />);
+  await screen.findByText(FIXTURE_TITLE);
+}
+
+function clickEntry(name: string) {
+  fireEvent.click(screen.getByText(name));
+}
+
+async function save() {
+  fireEvent.click(screen.getByRole("button", { name: "保存草稿" }));
+  await screen.findByText(/已保存于/);
+}
+
+describe("World Import Review flow", () => {
+  it("loads the fixture and shows the overview with category filtering", async () => {
+    await renderReview(newStore());
+
+    // All nine fixture entries are listed.
+    for (const name of [
+      "路明非",
+      "诺诺",
+      "龙类研究会",
+      "血统压制",
+      "卡塞尔学院",
+      "村雨",
+      "言灵",
+      "路明非收到录取通知",
+      "路明非 → 诺诺:单向关注",
+    ]) {
+      expect(screen.getByText(name)).toBeDefined();
+    }
+    // Fresh fixture has one unresolved conflict — the export warning shows.
+    expect(screen.getByText(/仍有 1 个冲突未标记解决/)).toBeDefined();
+
+    // Category filter narrows the list to characters only.
+    fireEvent.click(screen.getByRole("button", { name: "人物" }));
+    expect(screen.getByText("路明非")).toBeDefined();
+    expect(screen.getByText("诺诺")).toBeDefined();
+    expect(screen.queryByText("村雨")).toBeNull();
+    expect(screen.queryByText("血统压制")).toBeNull();
+
+    // Back to all.
+    fireEvent.click(screen.getByRole("button", { name: "全部" }));
+    expect(screen.getByText("村雨")).toBeDefined();
+  });
+
+  it("shows source locators for source-backed entries and flags pure AI inferences", async () => {
+    await renderReview(newStore());
+
+    clickEntry("路明非");
+    expect(
+      await screen.findByRole("heading", { name: "路明非" }),
+    ).toBeDefined();
+    expect(screen.getByText("第一章 · 卡塞尔学院的邀请函")).toBeDefined();
+    expect(screen.getByText(/欢迎路明非同学加入卡塞尔学院/)).toBeDefined();
+
+    clickEntry("龙类研究会");
+    expect(await screen.findByText(/无来源引用/)).toBeDefined();
+  });
+
+  it("edit persistence: edit name, save, reopen shows the edited draft", async () => {
+    const store = newStore();
+    await renderReview(store);
+
+    clickEntry("路明非");
+    const nameInput = await screen.findByRole("textbox", { name: "名称" });
+    fireEvent.change(nameInput, { target: { value: "路明非(已审)" } });
+    expect(screen.getAllByText("已人工编辑").length).toBeGreaterThan(0);
+
+    await save();
+    cleanup();
+
+    await renderReview(store);
+    expect(await screen.findByText("路明非(已审)")).toBeDefined();
+    // Fresh load is not dirty; save is disabled again.
+    expect(
+      screen.getByRole("button", { name: "保存草稿" }).hasAttribute("disabled"),
+    ).toBe(true);
+  });
+
+  it("accepts an AI inference and the decision survives save + reopen", async () => {
+    const store = newStore();
+    await renderReview(store);
+
+    clickEntry("龙类研究会");
+    fireEvent.click(
+      await screen.findByRole("button", { name: "接受 AI 推断" }),
+    );
+    expect(screen.getAllByText("已接受").length).toBeGreaterThan(0);
+    await save();
+    cleanup();
+
+    await renderReview(store);
+    clickEntry("龙类研究会");
+    await waitFor(() => {
+      expect(screen.getAllByText("已接受").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("deletes an AI inference only after explicit confirmation", async () => {
+    const store = newStore();
+    await renderReview(store);
+    const confirmSpy = vi
+      .spyOn(window, "confirm")
+      .mockImplementation(() => false);
+
+    clickEntry("路明非 → 诺诺:单向关注");
+    fireEvent.click(
+      await screen.findByRole("button", { name: "删除 AI 推断" }),
+    );
+    await waitFor(() => expect(confirmSpy).toHaveBeenCalled());
+    // Refused — entry stays (listed once, plus the detail heading).
+    expect(
+      screen.getAllByText("路明非 → 诺诺:单向关注").length,
+    ).toBeGreaterThan(0);
+
+    confirmSpy.mockImplementation(() => true);
+    fireEvent.click(screen.getByRole("button", { name: "删除 AI 推断" }));
+    await waitFor(() => {
+      expect(screen.queryByText("路明非 → 诺诺:单向关注")).toBeNull();
+    });
+  });
+
+  it("resolves a conflict: edits notes, marks resolved, survives save + reopen", async () => {
+    const store = newStore();
+    await renderReview(store);
+
+    clickEntry("血统压制");
+    const notes = await screen.findByRole("textbox", { name: "冲突说明" });
+    fireEvent.change(notes, {
+      target: { value: "已复核两处来源,以评级条款为准。" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "标记冲突已解决" }));
+    expect(screen.getAllByText("已解决").length).toBeGreaterThan(0);
+    await save();
+    // Live warning disappears once the conflict is resolved.
+    expect(screen.queryByText(/仍有 1 个冲突未标记解决/)).toBeNull();
+    cleanup();
+
+    await renderReview(store);
+    clickEntry("血统压制");
+    const notesAfter = await screen.findByRole("textbox", {
+      name: "冲突说明",
+    });
+    expect((notesAfter as HTMLTextAreaElement).value).toBe(
+      "已复核两处来源,以评级条款为准。",
+    );
+    expect(screen.getByRole("button", { name: "取消解决标记" })).toBeDefined();
+  });
+
+  it("reset to fixture discards saved edits", async () => {
+    const store = newStore();
+    await renderReview(store);
+    vi.spyOn(window, "confirm").mockImplementation(() => true);
+
+    clickEntry("路明非");
+    const nameInput = await screen.findByRole("textbox", { name: "名称" });
+    fireEvent.change(nameInput, { target: { value: "路明非(已审)" } });
+    await save();
+
+    fireEvent.click(screen.getByRole("button", { name: "重置为 fixture" }));
+    // The page reloads the fixture asynchronously (loading state in between).
+    await screen.findByText("路明非", undefined, { timeout: 3000 });
+    expect(screen.queryByText("路明非(已审)")).toBeNull();
+  });
+});

--- a/apps/web/src/features/world-import-review/__tests__/schema.test.ts
+++ b/apps/web/src/features/world-import-review/__tests__/schema.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import fixtureDraftJson from "../fixture/world-import-draft-v0.json";
+import { parseWorldImportDraft } from "../types.js";
+
+describe("parseWorldImportDraft", () => {
+  it("accepts the frozen v0 fixture", () => {
+    const parsed = parseWorldImportDraft(fixtureDraftJson);
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      expect(parsed.draft.version).toBe("v0");
+      expect(parsed.draft.entries.length).toBe(9);
+      expect(parsed.draft.sources.length).toBe(1);
+    }
+  });
+
+  it("covers every entry type and provenance status required by the UI", () => {
+    const parsed = parseWorldImportDraft(fixtureDraftJson);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const types = new Set(parsed.draft.entries.map((e) => e.type));
+    expect([...types].sort()).toEqual(
+      [
+        "character",
+        "event",
+        "faction",
+        "item",
+        "location",
+        "power_system",
+        "relation",
+        "rule",
+      ].sort(),
+    );
+    const statuses = new Set(
+      parsed.draft.entries.map((e) => e.provenanceStatus),
+    );
+    expect(statuses).toEqual(
+      new Set(["source-backed", "ai-inferred", "conflict"]),
+    );
+  });
+
+  it("rejects entries with an unknown provenance status", () => {
+    const broken = {
+      version: "v0",
+      id: "x",
+      title: "t",
+      sources: [],
+      summary: "",
+      entries: [
+        {
+          id: "e1",
+          type: "character",
+          name: "n",
+          aliases: [],
+          content: "c",
+          provenanceStatus: "made-up",
+          sourceRefs: [],
+          userEdited: false,
+        },
+      ],
+    };
+    const parsed = parseWorldImportDraft(broken);
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.error).toContain("provenanceStatus");
+    }
+  });
+
+  it("rejects a draft missing its id", () => {
+    const parsed = parseWorldImportDraft({
+      version: "v0",
+      title: "t",
+      sources: [],
+      summary: "",
+      entries: [],
+    });
+    expect(parsed.ok).toBe(false);
+  });
+});

--- a/apps/web/src/features/world-import-review/components/entry-detail-panel.tsx
+++ b/apps/web/src/features/world-import-review/components/entry-detail-panel.tsx
@@ -1,0 +1,318 @@
+import { useTranslation } from "react-i18next";
+import { CheckCircle2, MousePointerClick, Plus, Trash2, X } from "lucide-react";
+import { Button } from "@/components/ui/button.js";
+import { inputCls, textareaCls } from "@/components/world/editor-helpers.js";
+import { requestConfirm } from "@/lib/confirm-channel.js";
+import { cn } from "@/lib/utils.js";
+import { resolveSourceTitle, type EntryEditPatch } from "../draft-actions.js";
+import type { WorldImportDraft, WorldImportDraftEntry } from "../types.js";
+import { ProvenanceBadge } from "./provenance-badge.js";
+
+/**
+ * Right pane of the review page: the owner-facing editor for one entry.
+ * Every content edit funnels through onEdit, which stamps userEdited.
+ */
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <label className="ui-eyebrow block mb-1.5 text-muted-foreground">
+      {children}
+    </label>
+  );
+}
+
+function AliasEditor({
+  entry,
+  onEdit,
+}: {
+  entry: WorldImportDraftEntry;
+  onEdit: (entryId: string, patch: EntryEditPatch) => void;
+}) {
+  const { t } = useTranslation();
+  const setAliases = (aliases: string[]) => onEdit(entry.id, { aliases });
+  return (
+    <div>
+      <FieldLabel>{t("worldImport.detail.aliases")}</FieldLabel>
+      <div className="flex flex-col gap-1.5">
+        {entry.aliases.map((alias, index) => (
+          <div key={`${index}-${alias}`} className="flex items-center gap-1.5">
+            <input
+              className={inputCls}
+              value={alias}
+              aria-label={t("worldImport.detail.aliasItem", {
+                index: index + 1,
+              })}
+              onChange={(event) =>
+                setAliases(
+                  entry.aliases.map((a, i) =>
+                    i === index ? event.target.value : a,
+                  ),
+                )
+              }
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label={t("worldImport.detail.removeAlias", {
+                index: index + 1,
+              })}
+              onClick={() =>
+                setAliases(entry.aliases.filter((_, i) => i !== index))
+              }
+            >
+              <X className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        ))}
+        <div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            onClick={() => setAliases([...entry.aliases, ""])}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {t("worldImport.detail.addAlias")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SourceRefsSection({
+  draft,
+  entry,
+}: {
+  draft: WorldImportDraft;
+  entry: WorldImportDraftEntry;
+}) {
+  const { t } = useTranslation();
+  if (entry.sourceRefs.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground border border-dashed border-border/70 rounded-(--radius-control) px-3 py-2.5">
+        {t("worldImport.detail.noSourceRefs")}
+      </p>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      {entry.sourceRefs.map((ref, index) => (
+        <div
+          key={`${ref.sourceId}-${index}`}
+          className="border border-border/70 rounded-(--radius-control) px-3 py-2.5"
+        >
+          <div className="text-xs font-medium">
+            {resolveSourceTitle(draft, ref.sourceId)}
+          </div>
+          <div className="mt-0.5 text-xs text-muted-foreground font-mono">
+            {ref.locator}
+          </div>
+          {ref.quote && (
+            <blockquote className="mt-1.5 border-l-2 border-border pl-2.5 text-xs text-muted-foreground italic">
+              {ref.quote}
+            </blockquote>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ConflictSection({
+  entry,
+  onEdit,
+  onResolveConflict,
+}: {
+  entry: WorldImportDraftEntry;
+  onEdit: (entryId: string, patch: EntryEditPatch) => void;
+  onResolveConflict: (entryId: string, resolved: boolean) => void;
+}) {
+  const { t } = useTranslation();
+  if (entry.provenanceStatus !== "conflict") return null;
+  return (
+    <section className="border border-destructive/40 bg-destructive/5 rounded-(--radius-control) p-3">
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <h3 className="ui-eyebrow text-destructive">
+          {t("worldImport.conflict.title")}
+        </h3>
+        {entry.conflictResolved && (
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-primary">
+            <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
+            {t("worldImport.conflict.resolved")}
+          </span>
+        )}
+      </div>
+      <FieldLabel>{t("worldImport.conflict.notes")}</FieldLabel>
+      <textarea
+        className={cn(textareaCls, "min-h-16")}
+        value={entry.conflictNotes ?? ""}
+        aria-label={t("worldImport.conflict.notes")}
+        onChange={(event) =>
+          onEdit(entry.id, { conflictNotes: event.target.value })
+        }
+      />
+      <div className="mt-2">
+        <Button
+          type="button"
+          variant={entry.conflictResolved ? "secondary" : "outline"}
+          size="sm"
+          onClick={() => onResolveConflict(entry.id, !entry.conflictResolved)}
+        >
+          {entry.conflictResolved
+            ? t("worldImport.conflict.unmark")
+            : t("worldImport.conflict.markResolved")}
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+function AiInferenceSection({
+  entry,
+  onAcceptAi,
+  onRemoveEntry,
+}: {
+  entry: WorldImportDraftEntry;
+  onAcceptAi: (entryId: string) => void;
+  onRemoveEntry: (entryId: string) => void;
+}) {
+  const { t } = useTranslation();
+  if (entry.provenanceStatus !== "ai-inferred") return null;
+  const handleDelete = async () => {
+    const approved = await requestConfirm({
+      title: t("worldImport.ai.deleteConfirmTitle"),
+      message: t("worldImport.ai.deleteConfirmMessage", { name: entry.name }),
+      confirmLabel: t("worldImport.ai.delete"),
+      cancelLabel: t("common.cancel"),
+    });
+    if (approved) onRemoveEntry(entry.id);
+  };
+  return (
+    <section className="border border-border/70 rounded-(--radius-control) p-3">
+      <h3 className="ui-eyebrow mb-2 text-muted-foreground">
+        {t("worldImport.ai.title")}
+      </h3>
+      <div className="flex items-center flex-wrap gap-2">
+        {entry.aiAccepted ? (
+          <span className="inline-flex items-center gap-1.5 text-sm font-medium text-primary">
+            <CheckCircle2 className="h-4 w-4" aria-hidden />
+            {t("worldImport.ai.accepted")}
+          </span>
+        ) : (
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={() => onAcceptAi(entry.id)}
+          >
+            <MousePointerClick className="h-3.5 w-3.5" />
+            {t("worldImport.ai.accept")}
+          </Button>
+        )}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="text-destructive"
+          onClick={() => void handleDelete()}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+          {t("worldImport.ai.delete")}
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+export interface EntryDetailPanelProps {
+  draft: WorldImportDraft;
+  entry: WorldImportDraftEntry | null;
+  onEdit: (entryId: string, patch: EntryEditPatch) => void;
+  onAcceptAi: (entryId: string) => void;
+  onRemoveEntry: (entryId: string) => void;
+  onResolveConflict: (entryId: string, resolved: boolean) => void;
+}
+
+export function EntryDetailPanel({
+  draft,
+  entry,
+  onEdit,
+  onAcceptAi,
+  onRemoveEntry,
+  onResolveConflict,
+}: EntryDetailPanelProps) {
+  const { t } = useTranslation();
+  if (!entry) {
+    return (
+      <div className="h-full min-h-40 flex flex-col items-center justify-center gap-2 border border-dashed border-border/70 rounded-(--radius-control) text-center px-6 py-10">
+        <p className="text-sm text-muted-foreground">
+          {t("worldImport.detail.noSelection")}
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-5">
+      <header className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-lg font-semibold leading-snug wrap-break-word">
+            {entry.name}
+          </h2>
+          <p className="ui-eyebrow mt-1 text-muted-foreground">
+            {t(`worldImport.category.${entry.type}`)}
+          </p>
+        </div>
+        <div className="flex items-center gap-1.5 shrink-0">
+          <ProvenanceBadge status={entry.provenanceStatus} />
+          {entry.userEdited && (
+            <span className="inline-flex items-center gap-1 text-[11px] font-medium text-primary border border-primary/40 rounded-(--radius-control) px-1.5 py-0.5">
+              {t("worldImport.detail.userEdited")}
+            </span>
+          )}
+        </div>
+      </header>
+
+      <AiInferenceSection
+        entry={entry}
+        onAcceptAi={onAcceptAi}
+        onRemoveEntry={onRemoveEntry}
+      />
+      <ConflictSection
+        entry={entry}
+        onEdit={onEdit}
+        onResolveConflict={onResolveConflict}
+      />
+
+      <div>
+        <FieldLabel>{t("worldImport.detail.name")}</FieldLabel>
+        <input
+          className={inputCls}
+          value={entry.name}
+          aria-label={t("worldImport.detail.name")}
+          onChange={(event) => onEdit(entry.id, { name: event.target.value })}
+        />
+      </div>
+
+      <AliasEditor entry={entry} onEdit={onEdit} />
+
+      <div>
+        <FieldLabel>{t("worldImport.detail.content")}</FieldLabel>
+        <textarea
+          className={cn(textareaCls, "min-h-36")}
+          value={entry.content}
+          aria-label={t("worldImport.detail.content")}
+          onChange={(event) =>
+            onEdit(entry.id, { content: event.target.value })
+          }
+        />
+      </div>
+
+      <div>
+        <FieldLabel>{t("worldImport.detail.sourceRefs")}</FieldLabel>
+        <SourceRefsSection draft={draft} entry={entry} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/world-import-review/components/entry-list-panel.tsx
+++ b/apps/web/src/features/world-import-review/components/entry-list-panel.tsx
@@ -1,0 +1,168 @@
+import { useTranslation } from "react-i18next";
+import { CheckCircle2, PencilLine } from "lucide-react";
+import { cn } from "@/lib/utils.js";
+import { countByType, filterEntriesByType } from "../draft-actions.js";
+import type {
+  EntryType,
+  WorldImportDraft,
+  WorldImportDraftEntry,
+} from "../types.js";
+import { ENTRY_TYPES } from "../types.js";
+import { ProvenanceBadge } from "./provenance-badge.js";
+
+/**
+ * Left pane of the review page: category filter and the entry list. The
+ * list keeps import order; provenance badges carry the at-a-glance signal.
+ */
+
+function CategoryChip({
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  label: string;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      aria-label={label}
+      className={cn(
+        "inline-flex items-center gap-1.5 h-7 px-2.5 text-xs rounded-(--radius-control) border transition-colors",
+        active
+          ? "border-primary/60 bg-primary/10 text-foreground"
+          : "border-border/70 text-muted-foreground hover:text-foreground hover:bg-muted/40",
+      )}
+    >
+      <span>{label}</span>
+      <span className="text-[10px] font-semibold tabular-nums opacity-75">
+        {count}
+      </span>
+    </button>
+  );
+}
+
+function EntryListItem({
+  entry,
+  selected,
+  onSelect,
+  typeLabel,
+}: {
+  entry: WorldImportDraftEntry;
+  selected: boolean;
+  onSelect: () => void;
+  typeLabel: string;
+}) {
+  const { t } = useTranslation();
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-current={selected ? "true" : undefined}
+      className={cn(
+        "w-full text-left border px-3 py-2.5 rounded-(--radius-control) transition-colors",
+        selected
+          ? "border-primary/60 bg-muted/60"
+          : "border-border/70 hover:bg-muted/40",
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="text-sm font-medium leading-snug">{entry.name}</span>
+        <ProvenanceBadge status={entry.provenanceStatus} className="shrink-0" />
+      </div>
+      {entry.aliases.length > 0 && (
+        <div className="mt-0.5 text-xs text-muted-foreground truncate">
+          {entry.aliases.join(" · ")}
+        </div>
+      )}
+      <div className="mt-1.5 flex items-center flex-wrap gap-1.5 text-[11px] text-muted-foreground">
+        <span className="border border-border/70 px-1.5 py-px rounded-(--radius-control)">
+          {typeLabel}
+        </span>
+        {entry.userEdited && (
+          <span className="inline-flex items-center gap-1 text-primary">
+            <PencilLine className="h-3 w-3" aria-hidden />
+            {t("worldImport.detail.userEdited")}
+          </span>
+        )}
+        {entry.provenanceStatus === "ai-inferred" && entry.aiAccepted && (
+          <span className="inline-flex items-center gap-1 text-primary">
+            <CheckCircle2 className="h-3 w-3" aria-hidden />
+            {t("worldImport.ai.accepted")}
+          </span>
+        )}
+        {entry.provenanceStatus === "conflict" && entry.conflictResolved && (
+          <span className="inline-flex items-center gap-1 text-primary">
+            <CheckCircle2 className="h-3 w-3" aria-hidden />
+            {t("worldImport.conflict.resolved")}
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}
+
+export interface EntryListPanelProps {
+  draft: WorldImportDraft;
+  activeType: EntryType | null;
+  onTypeChange: (type: EntryType | null) => void;
+  selectedEntryId: string | null;
+  onSelectEntry: (entryId: string) => void;
+}
+
+export function EntryListPanel({
+  draft,
+  activeType,
+  onTypeChange,
+  selectedEntryId,
+  onSelectEntry,
+}: EntryListPanelProps) {
+  const { t } = useTranslation();
+  const typeCounts = countByType(draft);
+  const visibleEntries = filterEntriesByType(draft, activeType);
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-1.5 mb-4">
+        <CategoryChip
+          label={t("worldImport.filter.all")}
+          count={draft.entries.length}
+          active={activeType === null}
+          onClick={() => onTypeChange(null)}
+        />
+        {ENTRY_TYPES.map((type) => (
+          <CategoryChip
+            key={type}
+            label={t(`worldImport.category.${type}`)}
+            count={typeCounts[type]}
+            active={activeType === type}
+            onClick={() => onTypeChange(type)}
+          />
+        ))}
+      </div>
+
+      {visibleEntries.length === 0 ? (
+        <p className="text-sm text-muted-foreground border border-dashed border-border/70 rounded-(--radius-control) px-3 py-6 text-center">
+          {t("worldImport.list.empty")}
+        </p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {visibleEntries.map((entry) => (
+            <EntryListItem
+              key={entry.id}
+              entry={entry}
+              selected={entry.id === selectedEntryId}
+              onSelect={() => onSelectEntry(entry.id)}
+              typeLabel={t(`worldImport.category.${entry.type}`)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/world-import-review/components/provenance-badge.tsx
+++ b/apps/web/src/features/world-import-review/components/provenance-badge.tsx
@@ -1,0 +1,57 @@
+import { BookOpen, Sparkles, TriangleAlert } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Badge } from "@/components/ui/badge.js";
+import { cn } from "@/lib/utils.js";
+import type { ProvenanceStatus } from "../types.js";
+
+/**
+ * Provenance is the core signal of the review UI: where did this entry's
+ * content come from. The three states map to the fixed WorldImportDraft
+ * contract and must stay visually distinct.
+ */
+
+const PROVENANCE_CONFIG: Record<
+  ProvenanceStatus,
+  {
+    icon: typeof BookOpen;
+    variant: "secondary" | "outline" | "destructive";
+    className: string;
+  }
+> = {
+  "source-backed": {
+    icon: BookOpen,
+    variant: "secondary",
+    className: "text-foreground",
+  },
+  "ai-inferred": {
+    icon: Sparkles,
+    variant: "outline",
+    className: "border-dashed text-muted-foreground",
+  },
+  conflict: {
+    icon: TriangleAlert,
+    variant: "destructive",
+    className: "",
+  },
+};
+
+export function ProvenanceBadge({
+  status,
+  className,
+}: {
+  status: ProvenanceStatus;
+  className?: string;
+}) {
+  const { t } = useTranslation();
+  const config = PROVENANCE_CONFIG[status];
+  const Icon = config.icon;
+  return (
+    <Badge
+      variant={config.variant}
+      className={cn("gap-1 font-medium", config.className, className)}
+    >
+      <Icon className="h-3 w-3" aria-hidden />
+      {t(`worldImport.provenance.${status}`)}
+    </Badge>
+  );
+}

--- a/apps/web/src/features/world-import-review/components/review-page.tsx
+++ b/apps/web/src/features/world-import-review/components/review-page.tsx
@@ -1,0 +1,238 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Download, RotateCcw, Save } from "lucide-react";
+import { Button } from "@/components/ui/button.js";
+import { requestConfirm } from "@/lib/confirm-channel.js";
+import { countByProvenance, findEntry } from "../draft-actions.js";
+import { downloadWorldImportDraft } from "../draft-service.js";
+import { WorldImportDraftStore } from "../draft-store.js";
+import { useDraftReview } from "../use-draft-review.js";
+import type { EntryType } from "../types.js";
+import { EntryDetailPanel } from "./entry-detail-panel.js";
+import { EntryListPanel } from "./entry-list-panel.js";
+import { ProvenanceBadge } from "./provenance-badge.js";
+
+/**
+ * World Import Review page — route /world-import-review.
+ *
+ * The owner-facing gate between AI extraction (Dev B) and the approved
+ * WorldImportDraft: inspect what was extracted, see what is source-backed
+ * vs AI-inferred vs conflicting, edit, decide, save, export.
+ */
+
+function StatChip({
+  label,
+  value,
+  emphasis,
+}: {
+  label: string;
+  value: number;
+  emphasis?: "destructive";
+}) {
+  return (
+    <div className="flex items-baseline gap-1.5">
+      <span
+        className={
+          emphasis === "destructive"
+            ? "text-lg font-semibold text-destructive tabular-nums"
+            : "text-lg font-semibold tabular-nums"
+        }
+      >
+        {value}
+      </span>
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+export function ReviewPage({ store }: { store?: WorldImportDraftStore }) {
+  const { t } = useTranslation();
+  const review = useDraftReview(store);
+  const [activeType, setActiveType] = useState<EntryType | null>(null);
+  const [selectedEntryId, setSelectedEntryId] = useState<string | null>(null);
+
+  const draft = review.draft;
+  const counts = draft ? countByProvenance(draft) : null;
+  const selectedEntry = draft ? findEntry(draft, selectedEntryId) : null;
+
+  const handleReset = async () => {
+    const approved = await requestConfirm({
+      title: t("worldImport.reset.confirmTitle"),
+      message: t("worldImport.reset.confirmMessage"),
+      confirmLabel: t("worldImport.reset.action"),
+      cancelLabel: t("common.cancel"),
+    });
+    if (!approved) return;
+    setSelectedEntryId(null);
+    await review.resetToFixture();
+  };
+
+  if (review.loadState.status === "loading") {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <p className="text-sm text-muted-foreground animate-pulse">
+          {t("worldImport.status.loading")}
+        </p>
+      </div>
+    );
+  }
+
+  if (review.loadState.status === "error" || !draft || !counts) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center gap-3 px-6 text-center">
+        <p className="text-sm text-destructive">
+          {review.loadState.status === "error"
+            ? review.loadState.message
+            : t("worldImport.status.error")}
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => void review.reload()}
+        >
+          <RotateCcw className="h-3.5 w-3.5" />
+          {t("worldImport.status.retry")}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full w-full overflow-y-auto overscroll-contain">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 md:px-10 py-5 md:py-8">
+        <header className="mb-6">
+          <p className="ui-eyebrow text-muted-foreground mb-2">
+            {t("worldImport.eyebrow")}
+          </p>
+          <div className="flex flex-wrap items-end justify-between gap-4">
+            <div className="min-w-0">
+              <h1 className="font-display font-bold tracking-tight text-2xl md:text-3xl leading-tight">
+                {draft.title}
+              </h1>
+              <p className="mt-1 text-xs text-muted-foreground font-mono">
+                {draft.id} ·{" "}
+                {t("worldImport.metaVersion", { version: draft.version })}
+              </p>
+            </div>
+            <div className="flex items-center flex-wrap gap-2">
+              <Button
+                type="button"
+                size="sm"
+                disabled={!review.dirty || review.saving}
+                onClick={() => void review.save()}
+              >
+                <Save className="h-3.5 w-3.5" />
+                {t("worldImport.action.save")}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => downloadWorldImportDraft(draft)}
+              >
+                <Download className="h-3.5 w-3.5" />
+                {t("worldImport.action.export")}
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="text-destructive"
+                disabled={review.resetting}
+                onClick={() => void handleReset()}
+              >
+                <RotateCcw className="h-3.5 w-3.5" />
+                {t("worldImport.reset.action")}
+              </Button>
+            </div>
+          </div>
+
+          <p className="mt-3 max-w-3xl text-sm text-muted-foreground leading-relaxed">
+            {draft.summary}
+          </p>
+
+          <div className="mt-3 flex items-center flex-wrap gap-x-4 gap-y-1.5">
+            {draft.sources.map((source) => (
+              <span
+                key={source.id}
+                className="inline-flex items-center gap-1.5 text-xs text-muted-foreground border border-border/70 rounded-(--radius-control) px-2 py-0.5"
+              >
+                <span
+                  className="h-1.5 w-1.5 rounded-full bg-(--accent-primary)"
+                  aria-hidden
+                />
+                {source.title}
+              </span>
+            ))}
+            <span className="text-xs text-muted-foreground">
+              {review.savedAt
+                ? t("worldImport.savedAt", {
+                    time: new Date(review.savedAt).toLocaleString(),
+                  })
+                : t("worldImport.notSavedYet")}
+            </span>
+            {review.dirty && (
+              <span className="text-xs font-medium text-primary">
+                {t("worldImport.unsaved")}
+              </span>
+            )}
+          </div>
+        </header>
+
+        <section className="flex flex-wrap items-center gap-x-5 gap-y-2 border-y border-border/70 py-3 mb-6">
+          <StatChip label={t("worldImport.stats.total")} value={counts.total} />
+          <StatChip
+            label={t("worldImport.stats.sourceBacked")}
+            value={counts.sourceBacked}
+          />
+          <StatChip
+            label={t("worldImport.stats.aiInferred")}
+            value={counts.aiInferred}
+          />
+          <StatChip
+            label={t("worldImport.stats.conflict")}
+            value={counts.conflict}
+            emphasis={
+              counts.unresolvedConflicts > 0 ? "destructive" : undefined
+            }
+          />
+          {counts.unresolvedConflicts > 0 && (
+            <ProvenanceBadge status="conflict" />
+          )}
+          {counts.unresolvedConflicts > 0 && (
+            <span className="text-xs text-destructive">
+              {t("worldImport.export.conflictWarning", {
+                count: counts.unresolvedConflicts,
+              })}
+            </span>
+          )}
+        </section>
+
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 items-start">
+          <div className="lg:col-span-5 lg:sticky lg:top-4">
+            <EntryListPanel
+              draft={draft}
+              activeType={activeType}
+              onTypeChange={setActiveType}
+              selectedEntryId={selectedEntryId}
+              onSelectEntry={setSelectedEntryId}
+            />
+          </div>
+          <div className="lg:col-span-7">
+            <EntryDetailPanel
+              draft={draft}
+              entry={selectedEntry}
+              onEdit={review.editEntry}
+              onAcceptAi={review.acceptAi}
+              onRemoveEntry={(entryId) => {
+                review.removeEntry(entryId);
+                if (entryId === selectedEntryId) setSelectedEntryId(null);
+              }}
+              onResolveConflict={review.resolveConflict}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/world-import-review/draft-actions.ts
+++ b/apps/web/src/features/world-import-review/draft-actions.ts
@@ -1,0 +1,152 @@
+import type {
+  EntryType,
+  ProvenanceStatus,
+  WorldImportDraft,
+  WorldImportDraftEntry,
+} from "./types.js";
+
+/**
+ * Pure state transitions over a WorldImportDraft. The review UI and its
+ * tests both go through these; no React and no persistence here.
+ */
+
+/** Content edits by the owner (name / aliases / content / conflict notes). */
+export type EntryEditPatch = Partial<
+  Pick<WorldImportDraftEntry, "name" | "aliases" | "content" | "conflictNotes">
+>;
+
+export function updateEntry(
+  draft: WorldImportDraft,
+  entryId: string,
+  patch: EntryEditPatch,
+): WorldImportDraft {
+  return {
+    ...draft,
+    entries: draft.entries.map((entry) =>
+      entry.id === entryId ? { ...entry, ...patch, userEdited: true } : entry,
+    ),
+  };
+}
+
+/** Owner decision to keep an AI-inferred entry. Never touches userEdited. */
+export function acceptAiInference(
+  draft: WorldImportDraft,
+  entryId: string,
+): WorldImportDraft {
+  return {
+    ...draft,
+    entries: draft.entries.map((entry) =>
+      entry.id === entryId && entry.provenanceStatus === "ai-inferred"
+        ? { ...entry, aiAccepted: true }
+        : entry,
+    ),
+  };
+}
+
+export function deleteEntry(
+  draft: WorldImportDraft,
+  entryId: string,
+): WorldImportDraft {
+  return {
+    ...draft,
+    entries: draft.entries.filter((entry) => entry.id !== entryId),
+  };
+}
+
+export function setConflictResolved(
+  draft: WorldImportDraft,
+  entryId: string,
+  resolved: boolean,
+): WorldImportDraft {
+  return {
+    ...draft,
+    entries: draft.entries.map((entry) =>
+      entry.id === entryId && entry.provenanceStatus === "conflict"
+        ? { ...entry, conflictResolved: resolved }
+        : entry,
+    ),
+  };
+}
+
+export function findEntry(
+  draft: WorldImportDraft,
+  entryId: string | null,
+): WorldImportDraftEntry | null {
+  if (!entryId) return null;
+  return draft.entries.find((entry) => entry.id === entryId) ?? null;
+}
+
+export function countByType(
+  draft: WorldImportDraft,
+): Record<EntryType, number> {
+  const counts = {
+    character: 0,
+    faction: 0,
+    location: 0,
+    item: 0,
+    rule: 0,
+    power_system: 0,
+    event: 0,
+    relation: 0,
+  } as Record<EntryType, number>;
+  for (const entry of draft.entries) {
+    counts[entry.type] += 1;
+  }
+  return counts;
+}
+
+export interface ProvenanceCounts {
+  readonly total: number;
+  readonly sourceBacked: number;
+  readonly aiInferred: number;
+  readonly conflict: number;
+  readonly unresolvedConflicts: number;
+}
+
+export function countByProvenance(draft: WorldImportDraft): ProvenanceCounts {
+  const counts = { total: draft.entries.length } as ProvenanceCounts & {
+    sourceBacked: number;
+    aiInferred: number;
+    conflict: number;
+    unresolvedConflicts: number;
+  };
+  counts.sourceBacked = 0;
+  counts.aiInferred = 0;
+  counts.conflict = 0;
+  counts.unresolvedConflicts = 0;
+  for (const entry of draft.entries) {
+    if (entry.provenanceStatus === "source-backed") counts.sourceBacked += 1;
+    if (entry.provenanceStatus === "ai-inferred") counts.aiInferred += 1;
+    if (entry.provenanceStatus === "conflict") {
+      counts.conflict += 1;
+      if (!entry.conflictResolved) counts.unresolvedConflicts += 1;
+    }
+  }
+  return counts;
+}
+
+export function filterEntriesByType(
+  draft: WorldImportDraft,
+  type: EntryType | null,
+): WorldImportDraftEntry[] {
+  if (!type) return draft.entries;
+  return draft.entries.filter((entry) => entry.type === type);
+}
+
+export function provenanceOrder(status: ProvenanceStatus): number {
+  // Conflicts first (they need the owner most), then AI inferences, then
+  // source-backed entries. Used only as a stable display hint, not a sort
+  // requirement — the list otherwise keeps import order.
+  if (status === "conflict") return 0;
+  if (status === "ai-inferred") return 1;
+  return 2;
+}
+
+export function resolveSourceTitle(
+  draft: WorldImportDraft,
+  sourceId: string,
+): string {
+  return (
+    draft.sources.find((source) => source.id === sourceId)?.title ?? sourceId
+  );
+}

--- a/apps/web/src/features/world-import-review/draft-service.ts
+++ b/apps/web/src/features/world-import-review/draft-service.ts
@@ -1,0 +1,42 @@
+import fixtureDraftJson from "./fixture/world-import-draft-v0.json";
+import { parseWorldImportDraft, type WorldImportDraft } from "./types.js";
+
+/**
+ * Draft intake seam for the review UI. Today it serves the frozen v0
+ * fixture (no dependency on Dev B's extraction branch); tomorrow the real
+ * pipeline hands its result over through the same async contract.
+ */
+
+const FIXTURE_LOAD_DELAY_MS = 120;
+
+export async function fetchFixtureDraft(): Promise<WorldImportDraft> {
+  await new Promise((resolve) => setTimeout(resolve, FIXTURE_LOAD_DELAY_MS));
+  const parsed = parseWorldImportDraft(fixtureDraftJson as unknown);
+  if (!parsed.ok) {
+    throw new Error(parsed.error);
+  }
+  return parsed.draft;
+}
+
+export function buildExportPayload(draft: WorldImportDraft): string {
+  return JSON.stringify(draft, null, 2);
+}
+
+export function exportFileName(draft: WorldImportDraft): string {
+  return `world-import-draft-${draft.id}.json`;
+}
+
+/** Trigger a browser download of the approved draft. */
+export function downloadWorldImportDraft(draft: WorldImportDraft): void {
+  const blob = new Blob([buildExportPayload(draft)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = exportFileName(draft);
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}

--- a/apps/web/src/features/world-import-review/draft-store.ts
+++ b/apps/web/src/features/world-import-review/draft-store.ts
@@ -1,0 +1,61 @@
+import Dexie, { type Table } from "dexie";
+import { parseWorldImportDraft, type WorldImportDraft } from "./types.js";
+
+/**
+ * Local persistence for world-import review drafts, so a saved draft
+ * survives refresh / reopen. Deliberately a small dedicated database —
+ * game data lives in BrowserVault and must not be mixed with review-only
+ * working state.
+ */
+
+export const WORLD_IMPORT_DRAFT_DB_NAME = "covel-world-import-review";
+
+interface DraftRecord {
+  readonly draftId: string;
+  readonly savedAt: string;
+  readonly draft: WorldImportDraft;
+}
+
+export interface SavedDraft {
+  readonly savedAt: string;
+  readonly draft: WorldImportDraft;
+}
+
+export class WorldImportDraftStore {
+  private readonly db: Dexie;
+  private readonly drafts: Table<DraftRecord, string>;
+
+  constructor(dbName: string = WORLD_IMPORT_DRAFT_DB_NAME) {
+    this.db = new Dexie(dbName);
+    this.db.version(1).stores({ drafts: "draftId" });
+    this.drafts = this.db.table("drafts");
+  }
+
+  async load(draftId: string): Promise<SavedDraft | null> {
+    const record = await this.drafts.get(draftId);
+    if (!record) return null;
+    // Validate on read: a corrupted or schema-drifted record must fail
+    // loudly instead of feeding broken data into the review UI.
+    const parsed = parseWorldImportDraft(record.draft);
+    if (!parsed.ok) {
+      throw new Error(
+        `Saved draft "${draftId}" failed validation: ${parsed.error}`,
+      );
+    }
+    return { savedAt: record.savedAt, draft: parsed.draft };
+  }
+
+  async save(draft: WorldImportDraft): Promise<string> {
+    const savedAt = new Date().toISOString();
+    await this.drafts.put({
+      draftId: draft.id,
+      savedAt,
+      draft,
+    });
+    return savedAt;
+  }
+
+  async clear(draftId: string): Promise<void> {
+    await this.drafts.delete(draftId);
+  }
+}

--- a/apps/web/src/features/world-import-review/fixture/world-import-draft-v0.json
+++ b/apps/web/src/features/world-import-review/fixture/world-import-draft-v0.json
@@ -1,0 +1,159 @@
+{
+  "version": "v0",
+  "id": "world-import-fixture-longzu-v0",
+  "title": "龙族 I · 火之晨曦 — 世界导入草稿(审阅用 Fixture)",
+  "sources": [
+    {
+      "id": "src-longzu-book1-txt",
+      "title": "龙族 I · 火之晨曦(Owner 提供 TXT)",
+      "locatorHint": "章节名 + 段落位置"
+    }
+  ],
+  "summary": "从《龙族 I》正文整理出的卡塞尔学院世界观草稿:包含 2009 年入学窗口的人物、势力、地点、物品、规则、力量体系与关键事件。本文件仅为 UI 开发用的代表性 fixture,内容为示意整理,不代表 Canon Corpus 的最终结论。",
+  "entries": [
+    {
+      "id": "char-lu-mingfei",
+      "type": "character",
+      "name": "路明非",
+      "aliases": ["路少爷"],
+      "content": "2009 年的普通高三学生,成绩平平,寄住在叔叔婶婶家中。收到卡塞尔学院的录取邮件后进入学院,入学评估中表现出意料之外的血统反应。",
+      "provenanceStatus": "source-backed",
+      "sourceRefs": [
+        {
+          "sourceId": "src-longzu-book1-txt",
+          "locator": "第一章 · 卡塞尔学院的邀请函",
+          "quote": "电子邮件只有短短几行……欢迎路明非同学加入卡塞尔学院。"
+        }
+      ],
+      "userEdited": false
+    },
+    {
+      "id": "char-nono",
+      "type": "character",
+      "name": "诺诺",
+      "aliases": ["陈墨瞳", "Nono"],
+      "content": "卡塞尔学院的高年级学生,诺诺是她在学院里的通用称呼。性格张扬,是新生眼中的传奇人物。",
+      "provenanceStatus": "source-backed",
+      "sourceRefs": [
+        {
+          "sourceId": "src-longzu-book1-txt",
+          "locator": "第二章 · 学院初见",
+          "quote": "所有人都叫她诺诺。"
+        }
+      ],
+      "userEdited": false
+    },
+    {
+      "id": "faction-dragon-research",
+      "type": "faction",
+      "name": "龙类研究会",
+      "aliases": [],
+      "content": "【AI 推断】正文多处提到学院内存在研究龙类历史与血统的学生团体,但未出现明确组织名。此处暂定名\"龙类研究会\",等待 Owner 对照原文确认或改名。",
+      "provenanceStatus": "ai-inferred",
+      "sourceRefs": [],
+      "userEdited": false
+    },
+    {
+      "id": "rule-blood-suppression",
+      "type": "rule",
+      "name": "血统压制",
+      "aliases": [],
+      "content": "混血种的言灵强度受血统纯度影响;高血统者对低血统者存在直觉层面的压制。",
+      "provenanceStatus": "conflict",
+      "sourceRefs": [
+        {
+          "sourceId": "src-longzu-book1-txt",
+          "locator": "第三章 · 血统评估",
+          "quote": "评级越高的学生,能使用的言灵越强。"
+        },
+        {
+          "sourceId": "src-longzu-book1-txt",
+          "locator": "第五章 · 训练场对峙",
+          "quote": "决定胜负的从来不只是血统评级。"
+        }
+      ],
+      "conflictNotes": "两处来源对\"血统评级是否决定言灵强度\"的表述不一致:一处强调评级决定强度,另一处给出反例暗示还存在其他因素。需要 Owner 裁决该规则在游戏世界中的确切表述。",
+      "userEdited": false
+    },
+    {
+      "id": "location-kassel-academy",
+      "type": "location",
+      "name": "卡塞尔学院",
+      "aliases": ["Cassel College"],
+      "content": "坐落于芝加哥郊外的混血种精英学院,对外以私立名校作为掩护。学院内设有图书馆、训练场与学生社团设施。",
+      "provenanceStatus": "source-backed",
+      "sourceRefs": [
+        {
+          "sourceId": "src-longzu-book1-txt",
+          "locator": "第一章 · 卡塞尔学院的邀请函",
+          "quote": "学校位于芝加哥的郊外。"
+        }
+      ],
+      "userEdited": false
+    },
+    {
+      "id": "item-murasame",
+      "type": "item",
+      "name": "村雨",
+      "aliases": ["Murasame"],
+      "content": "一柄日本刀,平常以普通刀具的形态随身携带,在战斗中会显露锋芒。持有者日常将它带在身边。",
+      "provenanceStatus": "source-backed",
+      "sourceRefs": [
+        {
+          "sourceId": "src-longzu-book1-txt",
+          "locator": "第四章 · 执行部报到",
+          "quote": "他随身带着那把叫\"村雨\"的刀。"
+        }
+      ],
+      "userEdited": false
+    },
+    {
+      "id": "power-yanling",
+      "type": "power_system",
+      "name": "言灵",
+      "aliases": ["Yanling"],
+      "content": "混血种发动血统之力的统一体系,以\"言灵\"为单位释放能力。每个言灵有各自的名称、效果与代价,强度与使用者的血统评级相关(见规则条目\"血统压制\"的冲突)。",
+      "provenanceStatus": "source-backed",
+      "sourceRefs": [
+        {
+          "sourceId": "src-longzu-book1-txt",
+          "locator": "第三章 · 血统评估",
+          "quote": "他们把这种能力称为言灵。"
+        }
+      ],
+      "userEdited": false
+    },
+    {
+      "id": "event-admission-2009",
+      "type": "event",
+      "name": "路明非收到录取通知",
+      "aliases": [],
+      "content": "2009 年,路明非在自己家的电脑上收到卡塞尔学院的录取邮件,这封邮件把他从普通高中生的轨道上拉进了混血种的世界。",
+      "provenanceStatus": "source-backed",
+      "sourceRefs": [
+        {
+          "sourceId": "src-longzu-book1-txt",
+          "locator": "第一章 · 卡塞尔学院的邀请函",
+          "quote": "2009 年的那个夏天,这封邮件改变了一切。"
+        }
+      ],
+      "userEdited": false
+    },
+    {
+      "id": "relation-lu-nono",
+      "type": "relation",
+      "name": "路明非 → 诺诺:单向关注",
+      "aliases": [],
+      "content": "【AI 推断】路明非在入学前后多次注意到诺诺,并以她作为自己在学院中的目标之一。推断为单向的关注/憧憬关系,原文未出现双方关系的明确表述。",
+      "provenanceStatus": "ai-inferred",
+      "sourceRefs": [
+        {
+          "sourceId": "src-longzu-book1-txt",
+          "locator": "第二章 · 学院初见",
+          "quote": "他在人群里第一眼就看到了她。"
+        }
+      ],
+      "userEdited": false
+    }
+  ]
+}

--- a/apps/web/src/features/world-import-review/types.ts
+++ b/apps/web/src/features/world-import-review/types.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+
+/**
+ * WorldImportDraft v0 contract — the fixed shape Dev C's review UI and Dev
+ * B's extraction pipeline exchange. Everything the owner sees and edits in
+ * the review UI must survive a save / reopen / export round-trip.
+ *
+ * Two additive optional fields carry UI review decisions that must persist
+ * (the v0 contract has no other home for them):
+ *   - `aiAccepted` — the owner explicitly accepted an AI-inferred entry.
+ *   - `conflictResolved` — the owner marked a conflict entry as resolved.
+ * Both are absent in freshly imported drafts and set only by this UI.
+ */
+
+export const PROVENANCE_STATUSES = [
+  "source-backed",
+  "ai-inferred",
+  "conflict",
+] as const;
+
+export type ProvenanceStatus = (typeof PROVENANCE_STATUSES)[number];
+
+export const ENTRY_TYPES = [
+  "character",
+  "faction",
+  "location",
+  "item",
+  "rule",
+  "power_system",
+  "event",
+  "relation",
+] as const;
+
+export type EntryType = (typeof ENTRY_TYPES)[number];
+
+export const draftSourceSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  /** Human-readable hint describing what a locator points into. */
+  locatorHint: z.string().optional(),
+});
+
+export const sourceRefSchema = z.object({
+  sourceId: z.string().min(1),
+  /** Locator into the source, e.g. chapter / position — owner-readable. */
+  locator: z.string().min(1),
+  /** Optional short quoted snippet backing the entry. */
+  quote: z.string().optional(),
+});
+
+export const draftEntrySchema = z.object({
+  id: z.string().min(1),
+  type: z.enum(ENTRY_TYPES),
+  name: z.string().min(1),
+  aliases: z.array(z.string()),
+  content: z.string(),
+  provenanceStatus: z.enum(PROVENANCE_STATUSES),
+  sourceRefs: z.array(sourceRefSchema),
+  conflictNotes: z.string().optional(),
+  userEdited: z.boolean(),
+  aiAccepted: z.boolean().optional(),
+  conflictResolved: z.boolean().optional(),
+});
+
+export const worldImportDraftSchema = z.object({
+  version: z.string().min(1),
+  id: z.string().min(1),
+  title: z.string().min(1),
+  sources: z.array(draftSourceSchema),
+  summary: z.string(),
+  entries: z.array(draftEntrySchema),
+});
+
+export type DraftSource = z.infer<typeof draftSourceSchema>;
+export type SourceRef = z.infer<typeof sourceRefSchema>;
+export type WorldImportDraftEntry = z.infer<typeof draftEntrySchema>;
+export type WorldImportDraft = z.infer<typeof worldImportDraftSchema>;
+
+export function parseWorldImportDraft(
+  input: unknown,
+): { ok: true; draft: WorldImportDraft } | { ok: false; error: string } {
+  const result = worldImportDraftSchema.safeParse(input);
+  if (result.success) {
+    return { ok: true, draft: result.data };
+  }
+  const first = result.error.issues[0];
+  const path = first ? first.path.join(".") : "(root)";
+  return {
+    ok: false,
+    error: `WorldImportDraft validation failed at "${path}": ${first ? first.message : "unknown error"}`,
+  };
+}

--- a/apps/web/src/features/world-import-review/use-draft-review.ts
+++ b/apps/web/src/features/world-import-review/use-draft-review.ts
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  acceptAiInference,
+  deleteEntry,
+  setConflictResolved,
+  updateEntry,
+  type EntryEditPatch,
+} from "./draft-actions.js";
+import { fetchFixtureDraft } from "./draft-service.js";
+import { WorldImportDraftStore } from "./draft-store.js";
+import type { WorldImportDraft } from "./types.js";
+
+/**
+ * State owner for the review page. Loads the saved draft when one exists,
+ * otherwise falls back to the fixture; edits stay in memory until the owner
+ * explicitly saves.
+ */
+
+export type ReviewLoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready" };
+
+export interface DraftReview {
+  readonly loadState: ReviewLoadState;
+  readonly draft: WorldImportDraft | null;
+  readonly savedAt: string | null;
+  readonly dirty: boolean;
+  readonly saving: boolean;
+  readonly resetting: boolean;
+  editEntry(entryId: string, patch: EntryEditPatch): void;
+  acceptAi(entryId: string): void;
+  removeEntry(entryId: string): void;
+  resolveConflict(entryId: string, resolved: boolean): void;
+  save(): Promise<void>;
+  resetToFixture(): Promise<void>;
+  /** Re-run the initial load (saved draft first, fixture fallback). */
+  reload(): Promise<void>;
+}
+
+export function useDraftReview(
+  storeOverride?: WorldImportDraftStore,
+): DraftReview {
+  // Keep one store instance for the hook's lifetime: the load effect keys
+  // off it, and a per-render default would restart that effect forever.
+  const storeRef = useRef<WorldImportDraftStore | null>(null);
+  if (storeRef.current === null) {
+    storeRef.current = storeOverride ?? new WorldImportDraftStore();
+  }
+  const store = storeRef.current;
+  const [loadState, setLoadState] = useState<ReviewLoadState>({
+    status: "loading",
+  });
+  const [draft, setDraft] = useState<WorldImportDraft | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [resetting, setResetting] = useState(false);
+  const draftRef = useRef<WorldImportDraft | null>(null);
+  draftRef.current = draft;
+
+  const loadFrom = useCallback(
+    async (options: { preferSaved: boolean }) => {
+      setLoadState({ status: "loading" });
+      try {
+        const fixture = await fetchFixtureDraft();
+        const saved = options.preferSaved ? await store.load(fixture.id) : null;
+        setDraft(saved ? saved.draft : fixture);
+        setSavedAt(saved ? saved.savedAt : null);
+        setDirty(false);
+        setLoadState({ status: "ready" });
+      } catch (error) {
+        setLoadState({
+          status: "error",
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+    [store],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const fixture = await fetchFixtureDraft();
+        const saved = await store.load(fixture.id);
+        if (cancelled) return;
+        setDraft(saved ? saved.draft : fixture);
+        setSavedAt(saved ? saved.savedAt : null);
+        setDirty(false);
+        setLoadState({ status: "ready" });
+      } catch (error) {
+        if (cancelled) return;
+        setLoadState({
+          status: "error",
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [store]);
+
+  const mutate = useCallback(
+    (next: (prev: WorldImportDraft) => WorldImportDraft) => {
+      setDraft((prev) => (prev ? next(prev) : prev));
+      setDirty(true);
+    },
+    [],
+  );
+
+  const editEntry = useCallback(
+    (entryId: string, patch: EntryEditPatch) => {
+      mutate((prev) => updateEntry(prev, entryId, patch));
+    },
+    [mutate],
+  );
+
+  const acceptAi = useCallback(
+    (entryId: string) => {
+      mutate((prev) => acceptAiInference(prev, entryId));
+    },
+    [mutate],
+  );
+
+  const removeEntry = useCallback(
+    (entryId: string) => {
+      mutate((prev) => deleteEntry(prev, entryId));
+    },
+    [mutate],
+  );
+
+  const resolveConflict = useCallback(
+    (entryId: string, resolved: boolean) => {
+      mutate((prev) => setConflictResolved(prev, entryId, resolved));
+    },
+    [mutate],
+  );
+
+  const save = useCallback(async () => {
+    const current = draftRef.current;
+    if (!current) return;
+    setSaving(true);
+    try {
+      const at = await store.save(current);
+      setSavedAt(at);
+      setDirty(false);
+    } finally {
+      setSaving(false);
+    }
+  }, [store]);
+
+  const resetToFixture = useCallback(async () => {
+    const current = draftRef.current;
+    setResetting(true);
+    try {
+      if (current) {
+        await store.clear(current.id);
+      }
+      await loadFrom({ preferSaved: false });
+    } finally {
+      setResetting(false);
+    }
+  }, [store, loadFrom]);
+
+  return {
+    loadState,
+    draft,
+    savedAt,
+    dirty,
+    saving,
+    resetting,
+    editEntry,
+    acceptAi,
+    removeEntry,
+    resolveConflict,
+    save,
+    resetToFixture,
+    reload: () => loadFrom({ preferSaved: true }),
+  };
+}

--- a/apps/web/src/i18n/locales/en-US.json
+++ b/apps/web/src/i18n/locales/en-US.json
@@ -1326,5 +1326,83 @@
     "empty": "No character blueprints yet",
     "instantiated": "Instantiated",
     "blueprintOnly": "Blueprint only"
+  },
+  "worldImport": {
+    "eyebrow": "World Import · Review Desk",
+    "metaVersion": "Contract version {{version}}",
+    "action": {
+      "save": "Save draft",
+      "export": "Export JSON"
+    },
+    "reset": {
+      "action": "Reset to fixture",
+      "confirmTitle": "Reset to fixture?",
+      "confirmMessage": "Discards your saved draft edits and restores the original fixture content. This cannot be undone."
+    },
+    "savedAt": "Saved at {{time}}",
+    "notSavedYet": "Not saved yet",
+    "unsaved": "Unsaved changes",
+    "status": {
+      "loading": "Loading import draft…",
+      "error": "Failed to load the import draft",
+      "retry": "Retry"
+    },
+    "stats": {
+      "total": "Entries",
+      "sourceBacked": "Source-backed",
+      "aiInferred": "AI inferred",
+      "conflict": "Conflict"
+    },
+    "export": {
+      "conflictWarning": "Heads up: {{count}} conflict(s) are still unresolved."
+    },
+    "filter": {
+      "all": "All"
+    },
+    "category": {
+      "character": "Characters",
+      "faction": "Factions",
+      "location": "Locations",
+      "item": "Items",
+      "rule": "Rules",
+      "power_system": "Power systems",
+      "event": "Events",
+      "relation": "Relations"
+    },
+    "provenance": {
+      "source-backed": "Source-backed",
+      "ai-inferred": "AI inferred",
+      "conflict": "Conflict"
+    },
+    "list": {
+      "empty": "No entries in this category."
+    },
+    "detail": {
+      "noSelection": "Select an entry on the left to inspect sources and edit.",
+      "name": "Name",
+      "aliases": "Aliases",
+      "aliasItem": "Alias {{index}}",
+      "removeAlias": "Remove alias {{index}}",
+      "addAlias": "Add alias",
+      "content": "Content",
+      "sourceRefs": "Source locators",
+      "noSourceRefs": "No source references — this entry is fully AI inferred.",
+      "userEdited": "Edited"
+    },
+    "conflict": {
+      "title": "Conflict resolution",
+      "notes": "Conflict notes",
+      "markResolved": "Mark conflict resolved",
+      "unmark": "Unmark resolution",
+      "resolved": "Resolved"
+    },
+    "ai": {
+      "title": "AI inference",
+      "accept": "Accept AI inference",
+      "accepted": "Accepted",
+      "delete": "Delete AI inference",
+      "deleteConfirmTitle": "Delete this AI inference?",
+      "deleteConfirmMessage": "Entry \"{{name}}\" will be removed. It cannot be recovered after saving, unless you reset to the fixture."
+    }
   }
 }

--- a/apps/web/src/i18n/locales/zh-CN.json
+++ b/apps/web/src/i18n/locales/zh-CN.json
@@ -1326,5 +1326,83 @@
     "empty": "暂无角色蓝图",
     "instantiated": "已生成角色",
     "blueprintOnly": "仅蓝图"
+  },
+  "worldImport": {
+    "eyebrow": "世界导入 · 审阅台",
+    "metaVersion": "契约版本 {{version}}",
+    "action": {
+      "save": "保存草稿",
+      "export": "导出 JSON"
+    },
+    "reset": {
+      "action": "重置为 fixture",
+      "confirmTitle": "重置为 fixture?",
+      "confirmMessage": "将丢弃已保存的草稿修改,恢复为导入 fixture 的原始内容。此操作不可撤销。"
+    },
+    "savedAt": "已保存于 {{time}}",
+    "notSavedYet": "尚未保存",
+    "unsaved": "有未保存的修改",
+    "status": {
+      "loading": "正在加载导入草稿…",
+      "error": "加载导入草稿失败",
+      "retry": "重试"
+    },
+    "stats": {
+      "total": "条目总数",
+      "sourceBacked": "原文支持",
+      "aiInferred": "AI 推断",
+      "conflict": "存在冲突"
+    },
+    "export": {
+      "conflictWarning": "导出前请注意:仍有 {{count}} 个冲突未标记解决。"
+    },
+    "filter": {
+      "all": "全部"
+    },
+    "category": {
+      "character": "人物",
+      "faction": "势力",
+      "location": "地点",
+      "item": "物品",
+      "rule": "规则",
+      "power_system": "力量体系",
+      "event": "事件",
+      "relation": "关系"
+    },
+    "provenance": {
+      "source-backed": "原文支持",
+      "ai-inferred": "AI 推断",
+      "conflict": "存在冲突"
+    },
+    "list": {
+      "empty": "该类别暂无条目"
+    },
+    "detail": {
+      "noSelection": "从左侧选择一个条目,查看来源并编辑。",
+      "name": "名称",
+      "aliases": "别名",
+      "aliasItem": "别名 {{index}}",
+      "removeAlias": "删除别名 {{index}}",
+      "addAlias": "添加别名",
+      "content": "内容",
+      "sourceRefs": "来源定位",
+      "noSourceRefs": "无来源引用——该条目完全来自 AI 推断。",
+      "userEdited": "已人工编辑"
+    },
+    "conflict": {
+      "title": "冲突处理",
+      "notes": "冲突说明",
+      "markResolved": "标记冲突已解决",
+      "unmark": "取消解决标记",
+      "resolved": "已解决"
+    },
+    "ai": {
+      "title": "AI 推断处理",
+      "accept": "接受 AI 推断",
+      "accepted": "已接受",
+      "delete": "删除 AI 推断",
+      "deleteConfirmTitle": "删除这条 AI 推断?",
+      "deleteConfirmMessage": "将删除条目「{{name}}」。保存后不可恢复;可通过重置为 fixture 找回。"
+    }
   }
 }

--- a/apps/web/src/routes/world-import-review.tsx
+++ b/apps/web/src/routes/world-import-review.tsx
@@ -1,0 +1,22 @@
+import { Suspense, lazy } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+
+// Lazy-load the review page so its fixture + editor stay out of the main
+// app chunk, same split as the /debug surface.
+const ReviewPage = lazy(() =>
+  import("@/features/world-import-review/components/review-page.js").then(
+    (m) => ({ default: m.ReviewPage }),
+  ),
+);
+
+export const Route = createFileRoute("/world-import-review")({
+  component: WorldImportReviewPage,
+});
+
+function WorldImportReviewPage() {
+  return (
+    <Suspense fallback={null}>
+      <ReviewPage />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Summary / 摘要

Implements the Dongfang World Import Review / Edit UI: the owner-facing gate between AI world extraction and the approved WorldImportDraft. The owner must be able to see what was extracted, where each entry came from, and resolve conflicts before approving.

- New route **`/world-import-review`** (lazy-loaded, no changes to the existing nav system).
- Fixed **WorldImportDraft v0 contract** encoded as Zod schemas (`apps/web/src/features/world-import-review/types.ts`); all external input (fixture, saved drafts) is validated on load.
- Overview with per-category counts and filtering across 人物/势力/地点/物品/规则/力量体系/事件/关系; every entry visibly shows 原文支持 / AI 推断 / 存在冲突 provenance.
- Entry editor: rename, alias add/remove, content edit, source locator viewer (source title + locator + quote), accept AI inference, delete AI inference (confirm-guarded), edit conflict notes, mark conflict resolved.
- Every content edit stamps `userEdited = true`.
- Draft persistence in a small dedicated Dexie DB (`covel-world-import-review`) → save / reopen / refresh keeps all data. Reopen prefers the saved draft and falls back to the fixture.
- Export button downloads the approved draft as JSON (`world-import-draft-<id>.json`), with an unresolved-conflict warning.
- Intake is a **mock seam** (`draft-service.ts` serving the frozen v0 fixture) so this branch does not depend on the extraction pipeline.
- Fixture: `fixture/world-import-draft-v0.json` with 9 representative entries covering all 8 categories and all 3 provenance statuses (source-backed character, aliased character, AI-inferred faction, conflicting rule, location, item, power system, event, AI-inferred relation). Content is UI-development placeholder, not canon.
- Bilingual i18n (zh-CN / en-US) under `worldImport.*`; fixture content lives in a JSON data file, UI strings go through i18next (passes `check:i18n`).

Two additive **optional** fields extend the fixed contract for review decisions that must survive reopen (documented in `types.ts`): `aiAccepted?` (owner accepted an AI-inferred entry) and `conflictResolved?` (owner marked a conflict resolved). Everything else follows the contract exactly.

## Type of change / 变更类型

- [x] New feature / 新功能 (feat)

## Verification / 验证方式

- [x] `pnpm lint` (tsc + tailwind canonical, clean)
- [x] `pnpm test` — full `@covel/web` suite: **104 files / 650 tests passed** (24 new)
- [ ] `pnpm e2e` (not run; covered by component-level flow tests)
- [x] Manual check / 手动验证: real-browser walk-through of the full loop on the dev server — load fixture → browse categories → open entry → view source locators → edit (userEdited stamped) → accept AI inference → delete AI inference (confirm dialog) → resolve conflict → save → refresh → all data persists (verified on two fresh origins) → export JSON (payload contains `aiAccepted` / `conflictResolved` decisions). Screenshots: `devs/docs/review-ui-screenshots/` (local, gitignored).
- [x] New tests (24): schema parsing (fixture acceptance/rejection), pure draft transitions, Dexie store round-trip incl. corrupted-record rejection, and a component-level review-flow suite covering load/filter/edit/accept/delete/resolve/save/reopen/reset.

Baseline: branch cut at `ackness/covel@15f009d50d73ca985852bdb00322dcc721f56b6e` (exact frozen baseline).

## Related issue / context / 关联

Dongfang v1 work-stream C (World Import Review UI), developed against the fixed WorldImportDraft v0 contract; intake seam ready to be swapped for the real extraction pipeline handoff.

## Docs sync / 文档同步

- [x] No framework-visible contract changed (feature-local module; no `docs/reference/` update required)
