### PR TITLE
fix: preserve legacy deletion flows

### DIFF
--- a/apps/server/src/routes/api/session/session-guard.ts
+++ b/apps/server/src/routes/api/session/session-guard.ts
@@ -109,13 +109,26 @@ export function mintSessionApprovalScope(): string {
   return randomUUID();
 }
 
-/** Stable identity used to reject stale mutations after same-id recreation. */
+/**
+ * Stable identity used to reject stale mutations after same-id recreation.
+ *
+ * Sessions created before incarnation metadata was introduced still need to
+ * remain deletable after an in-place upgrade. Their owner hash is already a
+ * private, immutable random value; rows old enough to lack that hash fall back
+ * to their persisted id/creation time. Every current create path mints an
+ * incarnation nonce, so a recreated current row can never compare equal to a
+ * legacy row through either compatibility branch.
+ */
 export function sessionIncarnationIdentity(session: SessionRecord): string {
   const nonce = session.metadata?.[SESSION_INCARNATION_KEY];
   if (typeof nonce === "string" && nonce.length > 0) {
     return `incarnation:${nonce}`;
   }
-  throw new Error(`Session ${session.id} is missing incarnation metadata`);
+  const ownerHash = session.metadata?.[SESSION_OWNER_TOKEN_HASH_KEY];
+  if (typeof ownerHash === "string" && ownerHash.length > 0) {
+    return `legacy-owner:${ownerHash}`;
+  }
+  return `legacy-created:${session.id}:${session.createdAt}`;
 }
 
 /**

--- a/apps/server/tests/api/session-state.test.ts
+++ b/apps/server/tests/api/session-state.test.ts
@@ -274,6 +274,31 @@ describe("Session Routes", () => {
       expect(session).toBeNull();
     });
 
+    it("deletes a legacy session without incarnation metadata", async () => {
+      const sessionId = "legacy-player-world-session";
+      const now = new Date().toISOString();
+      await store.createSession({
+        id: sessionId,
+        worldId: "legacy-player-world",
+        status: "active",
+        phase: "playing",
+        completedPlayerTurns: 0,
+        setupRuntimes: {},
+        activePlugins: [],
+        locale: "zh-CN",
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const res = await app.request(`/api/sessions/${sessionId}`, {
+        method: "DELETE",
+      });
+
+      expect(res.status).toBe(200);
+      expect(await json(res)).toMatchObject({ deleted: true });
+      expect(await store.getSession(sessionId)).toBeNull();
+    });
+
     it("returns 404 for unknown session", async () => {
       const res = await app.request("/api/sessions/nonexistent", {
         method: "DELETE",

--- a/apps/web/src/components/session/__tests__/world-select-delete.test.tsx
+++ b/apps/web/src/components/session/__tests__/world-select-delete.test.tsx
@@ -63,12 +63,28 @@ describe("world select — deleting player-created worlds", () => {
     });
   });
 
-  it("offers the same delete action from custom-world details", () => {
+  it("confirms world deletion with Enter", async () => {
+    const deleteWorld = vi.spyOn(api, "deleteWorld").mockResolvedValue();
+    const onWorldDeleted = renderScreen();
+
+    fireEvent.click(screen.getByRole("button", { name: "删除世界" }));
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Enter" });
+
+    await waitFor(() => {
+      expect(deleteWorld).toHaveBeenCalledTimes(1);
+      expect(deleteWorld).toHaveBeenCalledWith("custom");
+      expect(onWorldDeleted).toHaveBeenCalledWith("custom");
+    });
+  });
+
+  it("opens the same delete confirmation from custom-world details", () => {
     renderScreen();
 
     const detailButtons = screen.getAllByRole("button", { name: "查看详情" });
     fireEvent.click(detailButtons[1]!);
 
-    expect(screen.getByRole("button", { name: "删除世界" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "删除世界" }));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByText("删除世界？")).toBeTruthy();
   });
 });

--- a/apps/web/src/components/session/left-panel.tsx
+++ b/apps/web/src/components/session/left-panel.tsx
@@ -218,7 +218,14 @@ export function LeftPanel({
           if (!open) setDeleteTarget(null);
         }}
       >
-        <DialogContent className="max-w-sm">
+        <DialogContent
+          className="max-w-sm"
+          onKeyDown={(event) => {
+            if (event.key !== "Enter" || deleting) return;
+            event.preventDefault();
+            void handleConfirmDelete();
+          }}
+        >
           <DialogHeader>
             <DialogTitle>
               {t("session.deleteConfirmTitle", "Delete Session")}
@@ -245,7 +252,8 @@ export function LeftPanel({
               variant="destructive"
               size="sm"
               disabled={deleting}
-              onClick={handleConfirmDelete}
+              aria-keyshortcuts="Enter"
+              onClick={() => void handleConfirmDelete()}
             >
               {deleting
                 ? t("common.deleting", "Deleting...")

--- a/apps/web/src/components/session/session-prep-screen.tsx
+++ b/apps/web/src/components/session/session-prep-screen.tsx
@@ -422,7 +422,14 @@ export function SessionPrepScreen({
           if (!open) setDeleteTarget(null);
         }}
       >
-        <DialogContent className="max-w-sm">
+        <DialogContent
+          className="max-w-sm"
+          onKeyDown={(event) => {
+            if (event.key !== "Enter" || deleting) return;
+            event.preventDefault();
+            void handleConfirmDelete();
+          }}
+        >
           <DialogHeader>
             <DialogTitle>
               {t("session.deleteConfirmTitle", "Delete Session")}
@@ -449,7 +456,8 @@ export function SessionPrepScreen({
               variant="destructive"
               size="sm"
               disabled={deleting}
-              onClick={handleConfirmDelete}
+              aria-keyshortcuts="Enter"
+              onClick={() => void handleConfirmDelete()}
             >
               {deleting
                 ? t("common.deleting", "Deleting...")

--- a/apps/web/src/components/session/world-select-screen.tsx
+++ b/apps/web/src/components/session/world-select-screen.tsx
@@ -95,6 +95,7 @@ export function WorldSelectScreen({
   const [enteringWorldId, setEnteringWorldId] = useState<string | null>(null);
   const [deletingWorldId, setDeletingWorldId] = useState<string | null>(null);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   // Entering a world used to defer the actual navigation to
   // `requestAnimationFrame`, so the busy state could paint one frame first.
@@ -154,7 +155,8 @@ export function WorldSelectScreen({
   }
 
   async function handleDeleteConfirm() {
-    if (!deletingWorldId) return;
+    if (!deletingWorldId || deleting) return;
+    setDeleting(true);
     try {
       await api.deleteWorld(deletingWorldId);
       onWorldDeleted?.(deletingWorldId);
@@ -162,23 +164,81 @@ export function WorldSelectScreen({
     } catch {
       // toast already shown by api request handler
     } finally {
+      setDeleting(false);
       setDeletingWorldId(null);
       setDeleteConfirmOpen(false);
     }
   }
 
+  const deletingWorld = deletingWorldId
+    ? worlds.find((world) => world.id === deletingWorldId)
+    : null;
+  const deleteDialog = (
+    <Dialog open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
+      <DialogContent
+        className="max-w-sm"
+        onKeyDown={(event) => {
+          if (event.key !== "Enter" || deleting) return;
+          event.preventDefault();
+          void handleDeleteConfirm();
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>
+            {t("world.deleteConfirmTitle", "Delete world?")}
+          </DialogTitle>
+          <DialogDescription>
+            {t(
+              "world.deleteConfirmDesc",
+              'This will permanently delete "{{name}}". This action cannot be undone.',
+              {
+                name: deletingWorld
+                  ? text(deletingWorld.name)
+                  : deletingWorldId,
+              },
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex justify-end gap-2 mt-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={deleting}
+            onClick={() => setDeleteConfirmOpen(false)}
+          >
+            {t("common.cancel", "Cancel")}
+          </Button>
+          <Button
+            size="sm"
+            variant="destructive"
+            disabled={deleting}
+            aria-keyshortcuts="Enter"
+            onClick={() => void handleDeleteConfirm()}
+          >
+            {deleting
+              ? t("common.deleting", "Deleting...")
+              : t("world.deleteConfirmAction", "Delete")}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+
   if (mode === "detail" && selectedWorld) {
     return (
-      <WorldDetailView
-        world={selectedWorld}
-        onClose={handleBack}
-        onEdit={handleEditFromDetail}
-        onDelete={
-          isWorldDeletable(selectedWorld)
-            ? () => handleDeleteFromDetail(selectedWorld.id)
-            : undefined
-        }
-      />
+      <>
+        {deleteDialog}
+        <WorldDetailView
+          world={selectedWorld}
+          onClose={handleBack}
+          onEdit={handleEditFromDetail}
+          onDelete={
+            isWorldDeletable(selectedWorld)
+              ? () => handleDeleteFromDetail(selectedWorld.id)
+              : undefined
+          }
+        />
+      </>
     );
   }
 
@@ -192,48 +252,9 @@ export function WorldSelectScreen({
     );
   }
 
-  const deletingWorld = deletingWorldId
-    ? worlds.find((w) => w.id === deletingWorldId)
-    : null;
-
   return (
     <div className="flex h-full w-full overflow-hidden">
-      <Dialog open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>
-              {t("world.deleteConfirmTitle", "Delete world?")}
-            </DialogTitle>
-            <DialogDescription>
-              {t(
-                "world.deleteConfirmDesc",
-                'This will permanently delete "{{name}}". This action cannot be undone.',
-                {
-                  name: deletingWorld
-                    ? text(deletingWorld.name)
-                    : deletingWorldId,
-                },
-              )}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex justify-end gap-2 mt-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setDeleteConfirmOpen(false)}
-            >
-              {t("common.cancel", "Cancel")}
-            </Button>
-            <Button
-              size="sm"
-              variant="destructive"
-              onClick={handleDeleteConfirm}
-            >
-              {t("world.deleteConfirmAction", "Delete")}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      {deleteDialog}
       <SettingsDialog
         open={settingsOpen}
         onOpenChange={onSettingsOpenChange}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ This release turns the stage view, plugin UI, world data, and runtime context in
 
 ### Fixed
 
+- **Player-created worlds and their old sessions remain deletable after upgrade.** Sessions saved before incarnation metadata existed now use a stable compatibility identity during guarded deletion instead of failing with a 500; world and session confirmation dialogs also accept `Enter` as the confirm shortcut.
 - **Default Playwright runs are isolated and deterministic.** They use dedicated ports and a temporary MemoryStore, never reuse stale development servers, clean up their process trees, and require an explicit opt-in before calling live providers.
 - **Long-running memory and runtime work handles cancellation, retries, deadlines, and automatic snapshots consistently.** Failed or resumed executions keep their relevant context without duplicating stale session reads or losing trace identity.
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1145,6 +1145,8 @@ source 读取、schema 校验与 projection Worker 在 session 写锁外完成�
 
 显式复用同一 ID 只有在旧行完全删除后才会成功；删除尚在 hook/drain 阶段时创建返回重复 ID 的 `409`，调用方应在 DELETE 成功后重试。MediaStore 的 session ownership/ref 会随删除清除，新 incarnation 不会继承旧媒体访问权。
 
+升级前创建、尚未包含私有 incarnation metadata 的历史 session 仍可删除。服务端仅在请求隔离检查中使用其既有 owner hash 或持久化的 `(id, createdAt)` 作为兼容身份；当前创建路径仍始终铸造随机 incarnation nonce，同 ID 重建不会继承历史身份。
+
 **参数:**
 
 | 参数 | 位置 | 说明    |


### PR DESCRIPTION
## Summary

- keep pre-incarnation player sessions deletable after in-place upgrades without weakening current session-generation isolation
- confirm world and session deletion with Enter while preventing repeat submission during deletion
- render the delete confirmation from both the world list and world detail view

## Verification

- `pnpm --filter @covel/server test` (105 files passed, 830 tests passed, 2 files/16 tests skipped)
- `pnpm --filter @covel/web test` (111 files passed, 693 tests passed)
- `pnpm --filter @covel/server lint`
- `pnpm --filter @covel/web lint`
- `pnpm check:i18n`
- commit hooks, including root `pnpm lint`

## Release context

Required before creating the `v0.0.28` tag. The tag has not been created yet.